### PR TITLE
feat(v8.4.0): OrgOverseer schemas — OrgIdentity, OrgRepresentativeDelegation, SuccessionPolicy (PR-A1.2)

### DIFF
--- a/schemas/README.md
+++ b/schemas/README.md
@@ -2,7 +2,7 @@
 
 **Contract version:** 8.3.1
 **Min supported:** 6.0.0
-**Schemas:** 206
+**Schemas:** 209
 
 ## Schemas
 
@@ -214,6 +214,9 @@
 | panel-verdict | `https://schemas.0xhoneyjar.com/loa-hounfour/8.3.1/panel-verdict` | [panel-verdict.schema.json](panel-verdict.schema.json) |
 | deliberation-dissent | `https://schemas.0xhoneyjar.com/loa-hounfour/8.3.1/deliberation-dissent` | [deliberation-dissent.schema.json](deliberation-dissent.schema.json) |
 | cross-score-report | `https://schemas.0xhoneyjar.com/loa-hounfour/8.3.1/cross-score-report` | [cross-score-report.schema.json](cross-score-report.schema.json) |
+| org-identity | `https://schemas.0xhoneyjar.com/loa-hounfour/8.3.1/org-identity` | [org-identity.schema.json](org-identity.schema.json) |
+| org-representative-delegation | `https://schemas.0xhoneyjar.com/loa-hounfour/8.3.1/org-representative-delegation` | [org-representative-delegation.schema.json](org-representative-delegation.schema.json) |
+| succession-policy | `https://schemas.0xhoneyjar.com/loa-hounfour/8.3.1/succession-policy` | [succession-policy.schema.json](succession-policy.schema.json) |
 
 ## Usage
 

--- a/schemas/index.json
+++ b/schemas/index.json
@@ -2,7 +2,7 @@
   "$schema": "https://schemas.0xhoneyjar.com/loa-hounfour/index",
   "version": "8.3.1",
   "min_supported_version": "6.0.0",
-  "generated_at": "2026-05-05T01:06:06.941Z",
+  "generated_at": "2026-05-05T01:06:08.105Z",
   "schemas": [
     {
       "name": "jwt-claims",

--- a/schemas/index.json
+++ b/schemas/index.json
@@ -2,7 +2,7 @@
   "$schema": "https://schemas.0xhoneyjar.com/loa-hounfour/index",
   "version": "8.3.1",
   "min_supported_version": "6.0.0",
-  "generated_at": "2026-05-05T01:06:08.105Z",
+  "generated_at": "2026-05-05T01:06:09.746Z",
   "schemas": [
     {
       "name": "jwt-claims",

--- a/schemas/index.json
+++ b/schemas/index.json
@@ -2,7 +2,7 @@
   "$schema": "https://schemas.0xhoneyjar.com/loa-hounfour/index",
   "version": "8.3.1",
   "min_supported_version": "6.0.0",
-  "generated_at": "2026-05-05T01:02:14.866Z",
+  "generated_at": "2026-05-05T01:06:06.941Z",
   "schemas": [
     {
       "name": "jwt-claims",
@@ -1239,6 +1239,24 @@
       "$id": "https://schemas.0xhoneyjar.com/loa-hounfour/8.3.1/cross-score-report",
       "file": "cross-score-report.schema.json",
       "description": "Signed pairwise cross-scoring attestation. Cross-field rule (no-self-scoring) in constraints/CrossScoreReport.constraints.json."
+    },
+    {
+      "name": "org-identity",
+      "$id": "https://schemas.0xhoneyjar.com/loa-hounfour/8.3.1/org-identity",
+      "file": "org-identity.schema.json",
+      "description": "Org root identity: org_id + cold-storage public key + active representatives + constitutional hash. Cross-field rule OI-1 in constraints/OrgIdentity.constraints.json."
+    },
+    {
+      "name": "org-representative-delegation",
+      "$id": "https://schemas.0xhoneyjar.com/loa-hounfour/8.3.1/org-representative-delegation",
+      "file": "org-representative-delegation.schema.json",
+      "description": "Append-only delegation record binding org → representative, signed under a signing_context envelope. Cross-field rules in constraints/OrgRepresentativeDelegation.constraints.json (ORD-1..3)."
+    },
+    {
+      "name": "succession-policy",
+      "$id": "https://schemas.0xhoneyjar.com/loa-hounfour/8.3.1/succession-policy",
+      "file": "succession-policy.schema.json",
+      "description": "Constitutional thresholds enforcing the asymmetric ladder + non-decreasing cooldown invariants. Cross-field rules SP-1..2 in constraints/SuccessionPolicy.constraints.json."
     }
   ]
 }

--- a/schemas/org-identity.schema.json
+++ b/schemas/org-identity.schema.json
@@ -1,0 +1,348 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.0xhoneyjar.com/loa-hounfour/8.3.1/org-identity",
+  "additionalProperties": false,
+  "x-cross-field-validated": true,
+  "description": "Org root identity: org_id + cold-storage public key + active representatives + constitutional hash. Cross-field rule OI-1 in constraints/OrgIdentity.constraints.json.",
+  "type": "object",
+  "required": [
+    "org_id",
+    "org_public_key",
+    "current_representatives",
+    "constitutional_hash",
+    "created_at",
+    "updated_at"
+  ],
+  "properties": {
+    "org_id": {
+      "format": "uuid",
+      "description": "UUID v4 identifying the organization.",
+      "type": "string"
+    },
+    "org_public_key": {
+      "pattern": "^ed25519-pub:[A-Za-z0-9_-]{43,44}$",
+      "description": "Cold-storage Ed25519 public key bound to the org root of trust.",
+      "type": "string"
+    },
+    "current_representatives": {
+      "minItems": 1,
+      "description": "Snapshot of currently-active representative AgentIdentity records. SP-007 invariant: MUST contain at least one entry; consumer-side state-store rejects writes that would drain this array.",
+      "type": "array",
+      "items": {
+        "$id": "AgentIdentity",
+        "additionalProperties": false,
+        "x-cross-field-validated": true,
+        "description": "Canonical agent identity with capability-scoped trust (v6.0.0, BREAKING).",
+        "type": "object",
+        "required": [
+          "agent_id",
+          "display_name",
+          "agent_type",
+          "capabilities",
+          "trust_scopes",
+          "delegation_authority",
+          "max_delegation_depth",
+          "governance_weight",
+          "contract_version"
+        ],
+        "properties": {
+          "agent_id": {
+            "pattern": "^[a-z][a-z0-9_-]{2,63}$",
+            "description": "Unique agent identifier (lowercase, 3-64 chars).",
+            "type": "string"
+          },
+          "display_name": {
+            "minLength": 1,
+            "maxLength": 128,
+            "description": "Human-readable agent display name.",
+            "type": "string"
+          },
+          "agent_type": {
+            "$id": "AgentType",
+            "description": "Classification of agent type in the protocol.",
+            "anyOf": [
+              {
+                "const": "model",
+                "type": "string"
+              },
+              {
+                "const": "orchestrator",
+                "type": "string"
+              },
+              {
+                "const": "human",
+                "type": "string"
+              },
+              {
+                "const": "service",
+                "type": "string"
+              },
+              {
+                "const": "composite",
+                "type": "string"
+              }
+            ]
+          },
+          "capabilities": {
+            "minItems": 1,
+            "description": "Non-empty list of agent capabilities.",
+            "type": "array",
+            "items": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "trust_scopes": {
+            "$id": "CapabilityScopedTrust",
+            "additionalProperties": false,
+            "description": "Per-capability-scope trust levels with default fallback (v6.0.0, BREAKING).",
+            "type": "object",
+            "required": [
+              "scopes",
+              "default_level"
+            ],
+            "properties": {
+              "scopes": {
+                "additionalProperties": false,
+                "description": "Per-scope trust levels. Missing scopes fall back to default_level.",
+                "type": "object",
+                "properties": {
+                  "billing": {
+                    "$id": "TrustLevel",
+                    "description": "Trust level assigned to an agent. Forms a total order from untrusted to sovereign.",
+                    "anyOf": [
+                      {
+                        "const": "untrusted",
+                        "type": "string"
+                      },
+                      {
+                        "const": "basic",
+                        "type": "string"
+                      },
+                      {
+                        "const": "verified",
+                        "type": "string"
+                      },
+                      {
+                        "const": "trusted",
+                        "type": "string"
+                      },
+                      {
+                        "const": "sovereign",
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "governance": {
+                    "$id": "TrustLevel",
+                    "description": "Trust level assigned to an agent. Forms a total order from untrusted to sovereign.",
+                    "anyOf": [
+                      {
+                        "const": "untrusted",
+                        "type": "string"
+                      },
+                      {
+                        "const": "basic",
+                        "type": "string"
+                      },
+                      {
+                        "const": "verified",
+                        "type": "string"
+                      },
+                      {
+                        "const": "trusted",
+                        "type": "string"
+                      },
+                      {
+                        "const": "sovereign",
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "inference": {
+                    "$id": "TrustLevel",
+                    "description": "Trust level assigned to an agent. Forms a total order from untrusted to sovereign.",
+                    "anyOf": [
+                      {
+                        "const": "untrusted",
+                        "type": "string"
+                      },
+                      {
+                        "const": "basic",
+                        "type": "string"
+                      },
+                      {
+                        "const": "verified",
+                        "type": "string"
+                      },
+                      {
+                        "const": "trusted",
+                        "type": "string"
+                      },
+                      {
+                        "const": "sovereign",
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "delegation": {
+                    "$id": "TrustLevel",
+                    "description": "Trust level assigned to an agent. Forms a total order from untrusted to sovereign.",
+                    "anyOf": [
+                      {
+                        "const": "untrusted",
+                        "type": "string"
+                      },
+                      {
+                        "const": "basic",
+                        "type": "string"
+                      },
+                      {
+                        "const": "verified",
+                        "type": "string"
+                      },
+                      {
+                        "const": "trusted",
+                        "type": "string"
+                      },
+                      {
+                        "const": "sovereign",
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "audit": {
+                    "$id": "TrustLevel",
+                    "description": "Trust level assigned to an agent. Forms a total order from untrusted to sovereign.",
+                    "anyOf": [
+                      {
+                        "const": "untrusted",
+                        "type": "string"
+                      },
+                      {
+                        "const": "basic",
+                        "type": "string"
+                      },
+                      {
+                        "const": "verified",
+                        "type": "string"
+                      },
+                      {
+                        "const": "trusted",
+                        "type": "string"
+                      },
+                      {
+                        "const": "sovereign",
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "composition": {
+                    "$id": "TrustLevel",
+                    "description": "Trust level assigned to an agent. Forms a total order from untrusted to sovereign.",
+                    "anyOf": [
+                      {
+                        "const": "untrusted",
+                        "type": "string"
+                      },
+                      {
+                        "const": "basic",
+                        "type": "string"
+                      },
+                      {
+                        "const": "verified",
+                        "type": "string"
+                      },
+                      {
+                        "const": "trusted",
+                        "type": "string"
+                      },
+                      {
+                        "const": "sovereign",
+                        "type": "string"
+                      }
+                    ]
+                  }
+                }
+              },
+              "default_level": {
+                "$id": "TrustLevel",
+                "description": "Trust level assigned to an agent. Forms a total order from untrusted to sovereign.",
+                "anyOf": [
+                  {
+                    "const": "untrusted",
+                    "type": "string"
+                  },
+                  {
+                    "const": "basic",
+                    "type": "string"
+                  },
+                  {
+                    "const": "verified",
+                    "type": "string"
+                  },
+                  {
+                    "const": "trusted",
+                    "type": "string"
+                  },
+                  {
+                    "const": "sovereign",
+                    "type": "string"
+                  }
+                ]
+              }
+            }
+          },
+          "delegation_authority": {
+            "description": "Permissions this agent may delegate. Requires delegation scope >= verified.",
+            "type": "array",
+            "items": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "max_delegation_depth": {
+            "minimum": 0,
+            "maximum": 10,
+            "description": "Maximum delegation chain depth this agent may create.",
+            "type": "integer"
+          },
+          "governance_weight": {
+            "minimum": 0,
+            "maximum": 1,
+            "description": "Voting weight in governance proposals (0-1).",
+            "type": "number"
+          },
+          "metadata": {
+            "description": "Extensible metadata key-value store.",
+            "type": "object",
+            "patternProperties": {
+              "^(.*)$": {}
+            }
+          },
+          "contract_version": {
+            "pattern": "^\\d+\\.\\d+\\.\\d+$",
+            "description": "Protocol contract version.",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "constitutional_hash": {
+      "pattern": "^sha256:[a-f0-9]{64}$",
+      "description": "SHA-256 digest of the org's founding constraint set.",
+      "type": "string"
+    },
+    "created_at": {
+      "format": "date-time",
+      "description": "ISO 8601 timestamp at which the org was registered.",
+      "type": "string"
+    },
+    "updated_at": {
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of the most recent representative or hash update.",
+      "type": "string"
+    }
+  },
+  "$comment": "contract_version=8.3.1, min_supported=6.0.0"
+}

--- a/schemas/org-representative-delegation.schema.json
+++ b/schemas/org-representative-delegation.schema.json
@@ -331,7 +331,7 @@
       }
     },
     "capability_scope": {
-      "description": "Domain-specific capability scope. Keys are consumer-defined. Library does not interpret the contents; consumer-side authorization evaluates against this object.",
+      "description": "Domain-specific capability scope. Keys are consumer-defined. Library does not interpret the contents; consumer-side authorization evaluates against this object. JSON Schema emits `patternProperties` for this field by design — consumers MUST NOT add `additionalProperties: false` here, which would over-constrain otherwise-valid records. This is the only field in the schema that is intentionally open at the wire level; tightening will come (if needed) via a future MINOR addition.",
       "type": "object",
       "patternProperties": {
         "^(.*)$": {}
@@ -364,7 +364,7 @@
         },
         "revoked_by": {
           "pattern": "^[a-z][a-z0-9_-]{2,63}$",
-          "description": "agent_id of the actor that issued the revocation.",
+          "description": "Pattern matches `AgentIdentity.agent_id` (`^[a-z][a-z0-9_-]{2,63}$`) — this field references an agent in the consumer-side agent registry. Cross-record existence is consumer-enforced per NF-1.",
           "type": "string"
         },
         "reason": {

--- a/schemas/org-representative-delegation.schema.json
+++ b/schemas/org-representative-delegation.schema.json
@@ -1,0 +1,453 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.0xhoneyjar.com/loa-hounfour/8.3.1/org-representative-delegation",
+  "additionalProperties": false,
+  "x-cross-field-validated": true,
+  "description": "Append-only delegation record binding org → representative, signed under a signing_context envelope. Cross-field rules in constraints/OrgRepresentativeDelegation.constraints.json (ORD-1..3).",
+  "type": "object",
+  "required": [
+    "delegation_id",
+    "org_id",
+    "representative",
+    "capability_scope",
+    "expiry",
+    "granted_by",
+    "chain_depth",
+    "signature",
+    "signed_by",
+    "signing_key_id",
+    "signing_algorithm",
+    "signed_at",
+    "signing_context"
+  ],
+  "properties": {
+    "delegation_id": {
+      "format": "uuid",
+      "description": "UUID v4 identifying this delegation record.",
+      "type": "string"
+    },
+    "org_id": {
+      "format": "uuid",
+      "description": "UUID v4 of the org this delegation is scoped to.",
+      "type": "string"
+    },
+    "representative": {
+      "$id": "AgentIdentity",
+      "additionalProperties": false,
+      "x-cross-field-validated": true,
+      "description": "Canonical agent identity with capability-scoped trust (v6.0.0, BREAKING).",
+      "type": "object",
+      "required": [
+        "agent_id",
+        "display_name",
+        "agent_type",
+        "capabilities",
+        "trust_scopes",
+        "delegation_authority",
+        "max_delegation_depth",
+        "governance_weight",
+        "contract_version"
+      ],
+      "properties": {
+        "agent_id": {
+          "pattern": "^[a-z][a-z0-9_-]{2,63}$",
+          "description": "Unique agent identifier (lowercase, 3-64 chars).",
+          "type": "string"
+        },
+        "display_name": {
+          "minLength": 1,
+          "maxLength": 128,
+          "description": "Human-readable agent display name.",
+          "type": "string"
+        },
+        "agent_type": {
+          "$id": "AgentType",
+          "description": "Classification of agent type in the protocol.",
+          "anyOf": [
+            {
+              "const": "model",
+              "type": "string"
+            },
+            {
+              "const": "orchestrator",
+              "type": "string"
+            },
+            {
+              "const": "human",
+              "type": "string"
+            },
+            {
+              "const": "service",
+              "type": "string"
+            },
+            {
+              "const": "composite",
+              "type": "string"
+            }
+          ]
+        },
+        "capabilities": {
+          "minItems": 1,
+          "description": "Non-empty list of agent capabilities.",
+          "type": "array",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "trust_scopes": {
+          "$id": "CapabilityScopedTrust",
+          "additionalProperties": false,
+          "description": "Per-capability-scope trust levels with default fallback (v6.0.0, BREAKING).",
+          "type": "object",
+          "required": [
+            "scopes",
+            "default_level"
+          ],
+          "properties": {
+            "scopes": {
+              "additionalProperties": false,
+              "description": "Per-scope trust levels. Missing scopes fall back to default_level.",
+              "type": "object",
+              "properties": {
+                "billing": {
+                  "$id": "TrustLevel",
+                  "description": "Trust level assigned to an agent. Forms a total order from untrusted to sovereign.",
+                  "anyOf": [
+                    {
+                      "const": "untrusted",
+                      "type": "string"
+                    },
+                    {
+                      "const": "basic",
+                      "type": "string"
+                    },
+                    {
+                      "const": "verified",
+                      "type": "string"
+                    },
+                    {
+                      "const": "trusted",
+                      "type": "string"
+                    },
+                    {
+                      "const": "sovereign",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "governance": {
+                  "$id": "TrustLevel",
+                  "description": "Trust level assigned to an agent. Forms a total order from untrusted to sovereign.",
+                  "anyOf": [
+                    {
+                      "const": "untrusted",
+                      "type": "string"
+                    },
+                    {
+                      "const": "basic",
+                      "type": "string"
+                    },
+                    {
+                      "const": "verified",
+                      "type": "string"
+                    },
+                    {
+                      "const": "trusted",
+                      "type": "string"
+                    },
+                    {
+                      "const": "sovereign",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "inference": {
+                  "$id": "TrustLevel",
+                  "description": "Trust level assigned to an agent. Forms a total order from untrusted to sovereign.",
+                  "anyOf": [
+                    {
+                      "const": "untrusted",
+                      "type": "string"
+                    },
+                    {
+                      "const": "basic",
+                      "type": "string"
+                    },
+                    {
+                      "const": "verified",
+                      "type": "string"
+                    },
+                    {
+                      "const": "trusted",
+                      "type": "string"
+                    },
+                    {
+                      "const": "sovereign",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "delegation": {
+                  "$id": "TrustLevel",
+                  "description": "Trust level assigned to an agent. Forms a total order from untrusted to sovereign.",
+                  "anyOf": [
+                    {
+                      "const": "untrusted",
+                      "type": "string"
+                    },
+                    {
+                      "const": "basic",
+                      "type": "string"
+                    },
+                    {
+                      "const": "verified",
+                      "type": "string"
+                    },
+                    {
+                      "const": "trusted",
+                      "type": "string"
+                    },
+                    {
+                      "const": "sovereign",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "audit": {
+                  "$id": "TrustLevel",
+                  "description": "Trust level assigned to an agent. Forms a total order from untrusted to sovereign.",
+                  "anyOf": [
+                    {
+                      "const": "untrusted",
+                      "type": "string"
+                    },
+                    {
+                      "const": "basic",
+                      "type": "string"
+                    },
+                    {
+                      "const": "verified",
+                      "type": "string"
+                    },
+                    {
+                      "const": "trusted",
+                      "type": "string"
+                    },
+                    {
+                      "const": "sovereign",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "composition": {
+                  "$id": "TrustLevel",
+                  "description": "Trust level assigned to an agent. Forms a total order from untrusted to sovereign.",
+                  "anyOf": [
+                    {
+                      "const": "untrusted",
+                      "type": "string"
+                    },
+                    {
+                      "const": "basic",
+                      "type": "string"
+                    },
+                    {
+                      "const": "verified",
+                      "type": "string"
+                    },
+                    {
+                      "const": "trusted",
+                      "type": "string"
+                    },
+                    {
+                      "const": "sovereign",
+                      "type": "string"
+                    }
+                  ]
+                }
+              }
+            },
+            "default_level": {
+              "$id": "TrustLevel",
+              "description": "Trust level assigned to an agent. Forms a total order from untrusted to sovereign.",
+              "anyOf": [
+                {
+                  "const": "untrusted",
+                  "type": "string"
+                },
+                {
+                  "const": "basic",
+                  "type": "string"
+                },
+                {
+                  "const": "verified",
+                  "type": "string"
+                },
+                {
+                  "const": "trusted",
+                  "type": "string"
+                },
+                {
+                  "const": "sovereign",
+                  "type": "string"
+                }
+              ]
+            }
+          }
+        },
+        "delegation_authority": {
+          "description": "Permissions this agent may delegate. Requires delegation scope >= verified.",
+          "type": "array",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "max_delegation_depth": {
+          "minimum": 0,
+          "maximum": 10,
+          "description": "Maximum delegation chain depth this agent may create.",
+          "type": "integer"
+        },
+        "governance_weight": {
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Voting weight in governance proposals (0-1).",
+          "type": "number"
+        },
+        "metadata": {
+          "description": "Extensible metadata key-value store.",
+          "type": "object",
+          "patternProperties": {
+            "^(.*)$": {}
+          }
+        },
+        "contract_version": {
+          "pattern": "^\\d+\\.\\d+\\.\\d+$",
+          "description": "Protocol contract version.",
+          "type": "string"
+        }
+      }
+    },
+    "capability_scope": {
+      "description": "Domain-specific capability scope. Keys are consumer-defined. Library does not interpret the contents; consumer-side authorization evaluates against this object.",
+      "type": "object",
+      "patternProperties": {
+        "^(.*)$": {}
+      }
+    },
+    "expiry": {
+      "format": "date-time",
+      "description": "ISO 8601 timestamp after which this delegation is no longer effective.",
+      "type": "string"
+    },
+    "revocation": {
+      "additionalProperties": false,
+      "description": "Revocation envelope. When present, indicates this record marks the delegation as revoked.",
+      "type": "object",
+      "required": [
+        "revoked",
+        "revoked_at",
+        "revoked_by"
+      ],
+      "properties": {
+        "revoked": {
+          "description": "Append-only revocation flag. ORD-2 (runtime-deferred): once true, MUST NOT be set back to false in any subsequent record sharing this delegation_id.",
+          "type": "boolean"
+        },
+        "revoked_at": {
+          "format": "date-time",
+          "description": "ISO 8601 timestamp at which this delegation was revoked.",
+          "type": "string"
+        },
+        "revoked_by": {
+          "pattern": "^[a-z][a-z0-9_-]{2,63}$",
+          "description": "agent_id of the actor that issued the revocation.",
+          "type": "string"
+        },
+        "reason": {
+          "minLength": 1,
+          "maxLength": 1024,
+          "description": "Optional human-readable revocation reason.",
+          "type": "string"
+        }
+      }
+    },
+    "granted_by": {
+      "description": "Either the prior delegation_id (UUID v4) in the chain, or the literal genesis sentinel \"genesis:org-public-key\" indicating direct grant by the cold-storage org_public_key. ORD-3 verifies chain reachability via the is_valid_dag builtin.",
+      "anyOf": [
+        {
+          "format": "uuid",
+          "description": "delegation_id reference to the prior link in the chain.",
+          "type": "string"
+        },
+        {
+          "description": "Genesis sentinel — chain rooted directly at org_public_key.",
+          "const": "genesis:org-public-key",
+          "type": "string"
+        }
+      ]
+    },
+    "chain_depth": {
+      "minimum": 0,
+      "maximum": 20,
+      "description": "Asserted depth of this delegation in the chain (0 for genesis-granted). Hard cap of 20; ORD-3 cross-checks against actual chain reachability.",
+      "type": "integer"
+    },
+    "signature": {
+      "pattern": "^ed25519:[A-Za-z0-9_-]{86,88}$",
+      "description": "Ed25519 signature over RFC 8785 canonical JSON of all-other-fields. Verification is consumer-side per NF-1 (ORD-1, runtime-deferred).",
+      "type": "string"
+    },
+    "signed_by": {
+      "pattern": "^ed25519-pub:[A-Za-z0-9_-]{43,44}$",
+      "description": "Ed25519 public key identifier of the signer.",
+      "type": "string"
+    },
+    "signing_key_id": {
+      "minLength": 1,
+      "description": "Stable key identifier for rotation tracking on the consumer side.",
+      "type": "string"
+    },
+    "signing_algorithm": {
+      "description": "Pinned to ed25519 for v8.4.0; future versions MAY widen this union additively.",
+      "const": "ed25519",
+      "type": "string"
+    },
+    "signed_at": {
+      "format": "date-time",
+      "description": "ISO 8601 timestamp at which this delegation was signed.",
+      "type": "string"
+    },
+    "signing_context": {
+      "$id": "SigningContext",
+      "additionalProperties": false,
+      "description": "Audience/scope/contract_version envelope bound under signature for cross-context replay protection.",
+      "type": "object",
+      "required": [
+        "audience",
+        "scope",
+        "contract_version"
+      ],
+      "properties": {
+        "audience": {
+          "minLength": 1,
+          "description": "Consumer-defined identifier the signature is bound to (e.g., the org_id or service principal).",
+          "type": "string"
+        },
+        "scope": {
+          "minLength": 1,
+          "description": "Deliberation- or lifecycle-context binding (e.g., \"panel-v1/security-review\", \"org-delegation/grant\").",
+          "type": "string"
+        },
+        "contract_version": {
+          "pattern": "^\\d+\\.\\d+\\.\\d+$",
+          "description": "Semver-formatted protocol contract version pinned to the signing event.",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "$comment": "contract_version=8.3.1, min_supported=6.0.0"
+}

--- a/schemas/org-representative-delegation.schema.json
+++ b/schemas/org-representative-delegation.schema.json
@@ -344,7 +344,7 @@
     },
     "revocation": {
       "additionalProperties": false,
-      "description": "Revocation envelope. When present, indicates this record marks the delegation as revoked.",
+      "description": "Revocation envelope. When present, this record revokes the delegation. The `revoked` field is pinned to `true` so envelope-presence and boolean-value cannot disagree.",
       "type": "object",
       "required": [
         "revoked",
@@ -353,7 +353,8 @@
       ],
       "properties": {
         "revoked": {
-          "description": "Append-only revocation flag. ORD-2 (runtime-deferred): once true, MUST NOT be set back to false in any subsequent record sharing this delegation_id.",
+          "description": "Pinned to literal `true`. The presence of the revocation envelope is the semantic signal of revocation; the boolean is retained as an explicit sentinel so consumers do not need to reason about envelope presence. Setting `revoked: false` is structurally unrepresentable, which subsumes the ORD-2 append-only-revoked invariant at the schema layer (ORD-2 remains runtime-deferred for the cross-record \"no later record may reset to absent-envelope\" obligation).",
+          "const": true,
           "type": "boolean"
         },
         "revoked_at": {

--- a/schemas/succession-policy.schema.json
+++ b/schemas/succession-policy.schema.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.0xhoneyjar.com/loa-hounfour/8.3.1/succession-policy",
+  "additionalProperties": false,
+  "x-cross-field-validated": true,
+  "description": "Constitutional thresholds enforcing the asymmetric ladder + non-decreasing cooldown invariants. Cross-field rules SP-1..2 in constraints/SuccessionPolicy.constraints.json.",
+  "type": "object",
+  "required": [
+    "policy_id",
+    "org_id",
+    "amend",
+    "rotate",
+    "add",
+    "remove",
+    "effective_at"
+  ],
+  "properties": {
+    "policy_id": {
+      "format": "uuid",
+      "description": "UUID v4 identifying this policy.",
+      "type": "string"
+    },
+    "org_id": {
+      "format": "uuid",
+      "description": "UUID v4 of the org this policy is bound to.",
+      "type": "string"
+    },
+    "amend": {
+      "additionalProperties": false,
+      "description": "Per-action threshold + cooldown pair.",
+      "type": "object",
+      "required": [
+        "threshold",
+        "cooldown_seconds"
+      ],
+      "properties": {
+        "threshold": {
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Quorum fraction in [0, 1] required to enact this action. Compared across actions by the SP-1 asymmetric-ladder rule.",
+          "type": "number"
+        },
+        "cooldown_seconds": {
+          "minimum": 0,
+          "description": "Minimum elapsed seconds between successive actions of this kind. Compared across actions by the SP-2 non-decreasing-cooldown rule.",
+          "type": "integer"
+        }
+      }
+    },
+    "rotate": {
+      "additionalProperties": false,
+      "description": "Per-action threshold + cooldown pair.",
+      "type": "object",
+      "required": [
+        "threshold",
+        "cooldown_seconds"
+      ],
+      "properties": {
+        "threshold": {
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Quorum fraction in [0, 1] required to enact this action. Compared across actions by the SP-1 asymmetric-ladder rule.",
+          "type": "number"
+        },
+        "cooldown_seconds": {
+          "minimum": 0,
+          "description": "Minimum elapsed seconds between successive actions of this kind. Compared across actions by the SP-2 non-decreasing-cooldown rule.",
+          "type": "integer"
+        }
+      }
+    },
+    "add": {
+      "additionalProperties": false,
+      "description": "Per-action threshold + cooldown pair.",
+      "type": "object",
+      "required": [
+        "threshold",
+        "cooldown_seconds"
+      ],
+      "properties": {
+        "threshold": {
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Quorum fraction in [0, 1] required to enact this action. Compared across actions by the SP-1 asymmetric-ladder rule.",
+          "type": "number"
+        },
+        "cooldown_seconds": {
+          "minimum": 0,
+          "description": "Minimum elapsed seconds between successive actions of this kind. Compared across actions by the SP-2 non-decreasing-cooldown rule.",
+          "type": "integer"
+        }
+      }
+    },
+    "remove": {
+      "additionalProperties": false,
+      "description": "Per-action threshold + cooldown pair.",
+      "type": "object",
+      "required": [
+        "threshold",
+        "cooldown_seconds"
+      ],
+      "properties": {
+        "threshold": {
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Quorum fraction in [0, 1] required to enact this action. Compared across actions by the SP-1 asymmetric-ladder rule.",
+          "type": "number"
+        },
+        "cooldown_seconds": {
+          "minimum": 0,
+          "description": "Minimum elapsed seconds between successive actions of this kind. Compared across actions by the SP-2 non-decreasing-cooldown rule.",
+          "type": "integer"
+        }
+      }
+    },
+    "effective_at": {
+      "format": "date-time",
+      "description": "ISO 8601 timestamp from which this policy is in force.",
+      "type": "string"
+    }
+  },
+  "$comment": "contract_version=8.3.1, min_supported=6.0.0"
+}

--- a/scripts/generate-schemas.ts
+++ b/scripts/generate-schemas.ts
@@ -175,6 +175,10 @@ import { PanelDecisionArtifactSchema } from '../src/governance/panel-decision-ar
 import { PanelVerdictSchema } from '../src/governance/panel-verdict.js';
 import { DeliberationDissentSchema } from '../src/governance/deliberation-dissent.js';
 import { CrossScoreReportSchema } from '../src/governance/cross-score-report.js';
+// v8.4.0 — OrgOverseer (FR-B1..FR-B3)
+import { OrgIdentitySchema } from '../src/governance/org-identity.js';
+import { OrgRepresentativeDelegationSchema } from '../src/governance/org-representative-delegation.js';
+import { SuccessionPolicySchema } from '../src/governance/succession-policy.js';
 import { CONTRACT_VERSION, MIN_SUPPORTED_VERSION } from '../src/version.js';
 import { postProcessSchema } from './schema-postprocess.js';
 
@@ -441,6 +445,10 @@ const schemas = [
   { name: 'panel-verdict', schema: PanelVerdictSchema },
   { name: 'deliberation-dissent', schema: DeliberationDissentSchema },
   { name: 'cross-score-report', schema: CrossScoreReportSchema },
+  // v8.4.0 — OrgOverseer (FR-B1..FR-B3)
+  { name: 'org-identity', schema: OrgIdentitySchema },
+  { name: 'org-representative-delegation', schema: OrgRepresentativeDelegationSchema },
+  { name: 'succession-policy', schema: SuccessionPolicySchema },
 ];
 
 mkdirSync(outDir, { recursive: true });

--- a/src/governance/index.ts
+++ b/src/governance/index.ts
@@ -437,3 +437,22 @@ export {
   type PairwiseScore,
   type CrossScoreReport,
 } from './cross-score-report.js';
+
+// Schemas — OrgIdentity (v8.4.0, FR-B1)
+export {
+  OrgIdentitySchema,
+  type OrgIdentity,
+} from './org-identity.js';
+
+// Schemas — OrgRepresentativeDelegation (v8.4.0, FR-B2)
+export {
+  OrgRepresentativeDelegationSchema,
+  ORG_DELEGATION_GENESIS_SENTINEL,
+  type OrgRepresentativeDelegation,
+} from './org-representative-delegation.js';
+
+// Schemas — SuccessionPolicy (v8.4.0, FR-B3)
+export {
+  SuccessionPolicySchema,
+  type SuccessionPolicy,
+} from './succession-policy.js';

--- a/src/governance/org-identity.ts
+++ b/src/governance/org-identity.ts
@@ -1,0 +1,60 @@
+/**
+ * OrgIdentity — cold-storage org public key + current representatives + constitutional hash.
+ *
+ * Carries the long-lived cryptographic root of an organization (`org_public_key`),
+ * the snapshot of currently-active representative `AgentIdentity` records, and a
+ * `constitutional_hash` binding the org to its founding constraint set.
+ *
+ * The minimum-representative invariant (`current_representatives.length >= 1`,
+ * SP-007) is enforced both as a TypeBox `minItems: 1` field constraint and as
+ * the OI-1 rule in `constraints/OrgIdentity.constraints.json`. The constraint
+ * file binds cross-runner conformance; this schema enforces it at the
+ * library/structural level.
+ *
+ * @see SDD section 3.4.1 — OrgIdentity required fields
+ * @see Issue #61 — Source RFC
+ * @since v8.4.0 (FR-B1)
+ */
+import { Type, type Static } from '@sinclair/typebox';
+import { AgentIdentitySchema } from '../schemas/agent-identity.js';
+
+export const OrgIdentitySchema = Type.Object(
+  {
+    org_id: Type.String({
+      format: 'uuid',
+      description: 'UUID v4 identifying the organization.',
+    }),
+    org_public_key: Type.String({
+      pattern: '^ed25519-pub:[A-Za-z0-9_-]{43,44}$',
+      description: 'Cold-storage Ed25519 public key bound to the org root of trust.',
+    }),
+    current_representatives: Type.Array(AgentIdentitySchema, {
+      minItems: 1,
+      description:
+        'Snapshot of currently-active representative AgentIdentity records. '
+        + 'SP-007 invariant: MUST contain at least one entry; consumer-side '
+        + 'state-store rejects writes that would drain this array.',
+    }),
+    constitutional_hash: Type.String({
+      pattern: '^sha256:[a-f0-9]{64}$',
+      description: 'SHA-256 digest of the org\'s founding constraint set.',
+    }),
+    created_at: Type.String({
+      format: 'date-time',
+      description: 'ISO 8601 timestamp at which the org was registered.',
+    }),
+    updated_at: Type.String({
+      format: 'date-time',
+      description: 'ISO 8601 timestamp of the most recent representative or hash update.',
+    }),
+  },
+  {
+    $id: 'OrgIdentity',
+    additionalProperties: false,
+    'x-cross-field-validated': true,
+    description:
+      'Org root identity: org_id + cold-storage public key + active representatives + '
+      + 'constitutional hash. Cross-field rule OI-1 in constraints/OrgIdentity.constraints.json.',
+  },
+);
+export type OrgIdentity = Static<typeof OrgIdentitySchema>;

--- a/src/governance/org-representative-delegation.ts
+++ b/src/governance/org-representative-delegation.ts
@@ -48,7 +48,12 @@ export const OrgRepresentativeDelegationSchema = Type.Object(
       description:
         'Domain-specific capability scope. Keys are consumer-defined. '
         + 'Library does not interpret the contents; consumer-side authorization '
-        + 'evaluates against this object.',
+        + 'evaluates against this object. JSON Schema emits `patternProperties` '
+        + 'for this field by design — consumers MUST NOT add '
+        + '`additionalProperties: false` here, which would over-constrain '
+        + 'otherwise-valid records. This is the only field in the schema '
+        + 'that is intentionally open at the wire level; tightening will '
+        + 'come (if needed) via a future MINOR addition.',
     }),
     expiry: Type.String({
       format: 'date-time',
@@ -73,7 +78,10 @@ export const OrgRepresentativeDelegationSchema = Type.Object(
           }),
           revoked_by: Type.String({
             pattern: '^[a-z][a-z0-9_-]{2,63}$',
-            description: 'agent_id of the actor that issued the revocation.',
+            description:
+              'Pattern matches `AgentIdentity.agent_id` (`^[a-z][a-z0-9_-]{2,63}$`) — '
+              + 'this field references an agent in the consumer-side agent registry. '
+              + 'Cross-record existence is consumer-enforced per NF-1.',
           }),
           reason: Type.Optional(
             Type.String({

--- a/src/governance/org-representative-delegation.ts
+++ b/src/governance/org-representative-delegation.ts
@@ -57,10 +57,15 @@ export const OrgRepresentativeDelegationSchema = Type.Object(
     revocation: Type.Optional(
       Type.Object(
         {
-          revoked: Type.Boolean({
+          revoked: Type.Literal(true, {
             description:
-              'Append-only revocation flag. ORD-2 (runtime-deferred): once true, MUST NOT '
-              + 'be set back to false in any subsequent record sharing this delegation_id.',
+              'Pinned to literal `true`. The presence of the revocation envelope is the '
+              + 'semantic signal of revocation; the boolean is retained as an explicit '
+              + 'sentinel so consumers do not need to reason about envelope presence. '
+              + 'Setting `revoked: false` is structurally unrepresentable, which subsumes '
+              + 'the ORD-2 append-only-revoked invariant at the schema layer (ORD-2 '
+              + 'remains runtime-deferred for the cross-record "no later record may '
+              + 'reset to absent-envelope" obligation).',
           }),
           revoked_at: Type.String({
             format: 'date-time',
@@ -81,7 +86,9 @@ export const OrgRepresentativeDelegationSchema = Type.Object(
         {
           additionalProperties: false,
           description:
-            'Revocation envelope. When present, indicates this record marks the delegation as revoked.',
+            'Revocation envelope. When present, this record revokes the delegation. The '
+            + '`revoked` field is pinned to `true` so envelope-presence and boolean-value '
+            + 'cannot disagree.',
         },
       ),
     ),

--- a/src/governance/org-representative-delegation.ts
+++ b/src/governance/org-representative-delegation.ts
@@ -1,0 +1,145 @@
+/**
+ * OrgRepresentativeDelegation — append-only delegation log binding org public
+ * key → representative AgentIdentity, optionally chained through prior
+ * delegations to a genesis sentinel.
+ *
+ * Each record is Ed25519-signed and bears a `signing_context` envelope
+ * (audience = org_id, scope = `'org-delegation/grant'` | `'org-delegation/revoke'`,
+ * contract_version) to prevent cross-org and cross-lifecycle replay.
+ *
+ * The chain is rooted at the literal genesis sentinel string
+ * `"genesis:org-public-key"` (SDD section 3.6 ORD-3): the first delegation in
+ * a chain has `granted_by == "genesis:org-public-key"`; subsequent records
+ * have `granted_by == <prior-delegation-id>`. Maximum chain depth is 20.
+ *
+ * Cross-field rules ORD-1..3 (constraints/OrgRepresentativeDelegation.constraints.json):
+ *   - ORD-1: Ed25519 signature verification — *runtime-deferred* per NF-1
+ *   - ORD-2: revocation lifecycle append-only — *runtime-deferred* (single-record stateless)
+ *   - ORD-3: chain validity + depth bound — *library*, via `is_valid_dag` (PR-A1.3)
+ *
+ * @see SDD section 3.4.2 — OrgRepresentativeDelegation required fields, signing_context binding
+ * @see SDD section 3.6 — ORD-3 genesis sentinel encoding
+ * @see Issue #61 — Source RFC
+ * @since v8.4.0 (FR-B2)
+ */
+import { Type, type Static } from '@sinclair/typebox';
+import { AgentIdentitySchema } from '../schemas/agent-identity.js';
+import { SigningContextSchema } from './signing-context.js';
+
+/**
+ * Genesis sentinel literal string. The first delegation in a chain (granted
+ * directly by the cold-storage `org_public_key`) records `granted_by` as
+ * this exact value. Stable cross-runner per SDD section 3.6.
+ */
+export const ORG_DELEGATION_GENESIS_SENTINEL = 'genesis:org-public-key' as const;
+
+export const OrgRepresentativeDelegationSchema = Type.Object(
+  {
+    delegation_id: Type.String({
+      format: 'uuid',
+      description: 'UUID v4 identifying this delegation record.',
+    }),
+    org_id: Type.String({
+      format: 'uuid',
+      description: 'UUID v4 of the org this delegation is scoped to.',
+    }),
+    representative: AgentIdentitySchema,
+    capability_scope: Type.Record(Type.String(), Type.Unknown(), {
+      description:
+        'Domain-specific capability scope. Keys are consumer-defined. '
+        + 'Library does not interpret the contents; consumer-side authorization '
+        + 'evaluates against this object.',
+    }),
+    expiry: Type.String({
+      format: 'date-time',
+      description: 'ISO 8601 timestamp after which this delegation is no longer effective.',
+    }),
+    revocation: Type.Optional(
+      Type.Object(
+        {
+          revoked: Type.Boolean({
+            description:
+              'Append-only revocation flag. ORD-2 (runtime-deferred): once true, MUST NOT '
+              + 'be set back to false in any subsequent record sharing this delegation_id.',
+          }),
+          revoked_at: Type.String({
+            format: 'date-time',
+            description: 'ISO 8601 timestamp at which this delegation was revoked.',
+          }),
+          revoked_by: Type.String({
+            pattern: '^[a-z][a-z0-9_-]{2,63}$',
+            description: 'agent_id of the actor that issued the revocation.',
+          }),
+          reason: Type.Optional(
+            Type.String({
+              minLength: 1,
+              maxLength: 1024,
+              description: 'Optional human-readable revocation reason.',
+            }),
+          ),
+        },
+        {
+          additionalProperties: false,
+          description:
+            'Revocation envelope. When present, indicates this record marks the delegation as revoked.',
+        },
+      ),
+    ),
+    granted_by: Type.Union(
+      [
+        Type.String({
+          format: 'uuid',
+          description: 'delegation_id reference to the prior link in the chain.',
+        }),
+        Type.Literal(ORG_DELEGATION_GENESIS_SENTINEL, {
+          description: 'Genesis sentinel — chain rooted directly at org_public_key.',
+        }),
+      ],
+      {
+        description:
+          'Either the prior delegation_id (UUID v4) in the chain, or the literal genesis '
+          + 'sentinel "genesis:org-public-key" indicating direct grant by the cold-storage '
+          + 'org_public_key. ORD-3 verifies chain reachability via the is_valid_dag builtin.',
+      },
+    ),
+    chain_depth: Type.Integer({
+      minimum: 0,
+      maximum: 20,
+      description:
+        'Asserted depth of this delegation in the chain (0 for genesis-granted). '
+        + 'Hard cap of 20; ORD-3 cross-checks against actual chain reachability.',
+    }),
+    signature: Type.String({
+      pattern: '^ed25519:[A-Za-z0-9_-]{86,88}$',
+      description:
+        'Ed25519 signature over RFC 8785 canonical JSON of all-other-fields. '
+        + 'Verification is consumer-side per NF-1 (ORD-1, runtime-deferred).',
+    }),
+    signed_by: Type.String({
+      pattern: '^ed25519-pub:[A-Za-z0-9_-]{43,44}$',
+      description: 'Ed25519 public key identifier of the signer.',
+    }),
+    signing_key_id: Type.String({
+      minLength: 1,
+      description: 'Stable key identifier for rotation tracking on the consumer side.',
+    }),
+    signing_algorithm: Type.Literal('ed25519', {
+      description: 'Pinned to ed25519 for v8.4.0; future versions MAY widen this union additively.',
+    }),
+    signed_at: Type.String({
+      format: 'date-time',
+      description: 'ISO 8601 timestamp at which this delegation was signed.',
+    }),
+    signing_context: SigningContextSchema,
+  },
+  {
+    $id: 'OrgRepresentativeDelegation',
+    additionalProperties: false,
+    'x-cross-field-validated': true,
+    description:
+      'Append-only delegation record binding org → representative, signed under '
+      + 'a signing_context envelope. Cross-field rules in '
+      + 'constraints/OrgRepresentativeDelegation.constraints.json (ORD-1..3).',
+  },
+);
+export type OrgRepresentativeDelegation = Static<typeof OrgRepresentativeDelegationSchema>;

--- a/src/governance/succession-policy.ts
+++ b/src/governance/succession-policy.ts
@@ -1,0 +1,72 @@
+/**
+ * SuccessionPolicy — constitutional thresholds for representative-set actions.
+ *
+ * Pins the four constitutional actions (`amend`, `rotate`, `add`, `remove`)
+ * to per-action `threshold` (quorum fraction in [0, 1]) and `cooldown_seconds`
+ * (minimum elapsed time between actions of the same kind). The asymmetric
+ * ladder + non-decreasing cooldown invariants are declared in
+ * `constraints/SuccessionPolicy.constraints.json` (cross-field, library-evaluated).
+ *
+ * No `self_removal_allowed` field (OQ4 resolution): the SP-007 minimum-rep
+ * invariant on `OrgIdentity.current_representatives.length >= 1` blocks the
+ * write that would zero out reps; consumer-side runtime models the
+ * `governance.delegation.self_removal_pending` lifecycle.
+ *
+ * @see SDD section 3.4.3 — SuccessionPolicy required fields, cross-field rules
+ * @see Issue #61 — Source RFC, OQ4
+ * @since v8.4.0 (FR-B3)
+ */
+import { Type, type Static } from '@sinclair/typebox';
+
+const SuccessionActionRuleSchema = Type.Object(
+  {
+    threshold: Type.Number({
+      minimum: 0,
+      maximum: 1,
+      description:
+        'Quorum fraction in [0, 1] required to enact this action. Compared across '
+        + 'actions by the SP-1 asymmetric-ladder rule.',
+    }),
+    cooldown_seconds: Type.Integer({
+      minimum: 0,
+      description:
+        'Minimum elapsed seconds between successive actions of this kind. Compared '
+        + 'across actions by the SP-2 non-decreasing-cooldown rule.',
+    }),
+  },
+  {
+    additionalProperties: false,
+    description: 'Per-action threshold + cooldown pair.',
+  },
+);
+
+export const SuccessionPolicySchema = Type.Object(
+  {
+    policy_id: Type.String({
+      format: 'uuid',
+      description: 'UUID v4 identifying this policy.',
+    }),
+    org_id: Type.String({
+      format: 'uuid',
+      description: 'UUID v4 of the org this policy is bound to.',
+    }),
+    amend: SuccessionActionRuleSchema,
+    rotate: SuccessionActionRuleSchema,
+    add: SuccessionActionRuleSchema,
+    remove: SuccessionActionRuleSchema,
+    effective_at: Type.String({
+      format: 'date-time',
+      description: 'ISO 8601 timestamp from which this policy is in force.',
+    }),
+  },
+  {
+    $id: 'SuccessionPolicy',
+    additionalProperties: false,
+    'x-cross-field-validated': true,
+    description:
+      'Constitutional thresholds enforcing the asymmetric ladder + non-decreasing '
+      + 'cooldown invariants. Cross-field rules SP-1..2 in '
+      + 'constraints/SuccessionPolicy.constraints.json.',
+  },
+);
+export type SuccessionPolicy = Static<typeof SuccessionPolicySchema>;

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -72,6 +72,9 @@ import { PanelDecisionArtifactSchema } from '../governance/panel-decision-artifa
 import { PanelVerdictSchema } from '../governance/panel-verdict.js';
 import { DeliberationDissentSchema } from '../governance/deliberation-dissent.js';
 import { CrossScoreReportSchema } from '../governance/cross-score-report.js';
+import { OrgIdentitySchema } from '../governance/org-identity.js';
+import { OrgRepresentativeDelegationSchema } from '../governance/org-representative-delegation.js';
+import { SuccessionPolicySchema } from '../governance/succession-policy.js';
 
 // Compile cache — lazily populated on first use.
 // Only caches schemas with $id to prevent unbounded growth from
@@ -970,4 +973,9 @@ export const validators = {
   panelVerdict: () => getOrCompile(PanelVerdictSchema),
   deliberationDissent: () => getOrCompile(DeliberationDissentSchema),
   crossScoreReport: () => getOrCompile(CrossScoreReportSchema),
+
+  // v8.4.0 — OrgOverseer (FR-B1..FR-B3)
+  orgIdentity: () => getOrCompile(OrgIdentitySchema),
+  orgRepresentativeDelegation: () => getOrCompile(OrgRepresentativeDelegationSchema),
+  successionPolicy: () => getOrCompile(SuccessionPolicySchema),
 } as const;

--- a/tests/schemas/org-identity.test.ts
+++ b/tests/schemas/org-identity.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for OrgIdentitySchema (FR-B1, v8.4.0).
+ *
+ * Validates schema shape, required fields, and ≥5 mutation classes including
+ * the SP-007 minimum-rep invariant (current_representatives non-empty).
+ *
+ * Cross-field rule OI-1 is also enforced by the constraint file landing in
+ * PR-A1.4; this suite validates the TypeBox-level expression of the same
+ * invariant via `minItems: 1`.
+ */
+import { describe, it, expect } from 'vitest';
+import { Value } from '@sinclair/typebox/value';
+import {
+  OrgIdentitySchema,
+  type OrgIdentity,
+} from '../../src/governance/org-identity.js';
+import type { AgentIdentity } from '../../src/schemas/agent-identity.js';
+import '../../src/validators/index.js';
+
+const validAgent: AgentIdentity = {
+  agent_id: 'agent-alice',
+  display_name: 'Alice',
+  agent_type: 'human',
+  capabilities: ['governance'],
+  trust_scopes: {
+    scopes: {
+      billing: 'trusted',
+      governance: 'trusted',
+      inference: 'trusted',
+      delegation: 'trusted',
+      audit: 'trusted',
+      composition: 'trusted',
+    },
+    default_level: 'trusted',
+  },
+  delegation_authority: ['invoke'],
+  max_delegation_depth: 2,
+  governance_weight: 0.5,
+  contract_version: '8.4.0',
+};
+
+const ED25519_PUB = 'ed25519-pub:' + 'A'.repeat(43);
+const SHA256_HASH = 'sha256:' + 'a'.repeat(64);
+
+const validOrg: OrgIdentity = {
+  org_id: '550e8400-e29b-41d4-a716-446655440000',
+  org_public_key: ED25519_PUB,
+  current_representatives: [validAgent],
+  constitutional_hash: SHA256_HASH,
+  created_at: '2026-05-05T00:00:00Z',
+  updated_at: '2026-05-05T00:00:00Z',
+};
+
+describe('OrgIdentitySchema', () => {
+  it('validates a canonical fixture', () => {
+    expect(Value.Check(OrgIdentitySchema, validOrg)).toBe(true);
+  });
+
+  it('has $id = OrgIdentity', () => {
+    expect(OrgIdentitySchema.$id).toBe('OrgIdentity');
+  });
+
+  it('declares x-cross-field-validated:true', () => {
+    expect((OrgIdentitySchema as { 'x-cross-field-validated'?: boolean })['x-cross-field-validated']).toBe(true);
+  });
+
+  it('declares additionalProperties:false', () => {
+    expect((OrgIdentitySchema as { additionalProperties?: boolean }).additionalProperties).toBe(false);
+  });
+
+  // --- Mutation 1: SP-007 invariant (empty current_representatives) ---
+  it('rejects empty current_representatives (SP-007 minItems)', () => {
+    expect(Value.Check(OrgIdentitySchema, { ...validOrg, current_representatives: [] })).toBe(false);
+  });
+
+  // --- Mutation 2: invalid org_public_key pattern ---
+  it('rejects an org_public_key without the ed25519-pub: prefix', () => {
+    expect(Value.Check(OrgIdentitySchema, { ...validOrg, org_public_key: 'rsa-pub:' + 'A'.repeat(43) })).toBe(false);
+  });
+
+  it('rejects an org_public_key whose payload is too short', () => {
+    expect(Value.Check(OrgIdentitySchema, { ...validOrg, org_public_key: 'ed25519-pub:' + 'A'.repeat(40) })).toBe(false);
+  });
+
+  // --- Mutation 3: invalid constitutional_hash pattern ---
+  it('rejects a constitutional_hash without the sha256: prefix', () => {
+    expect(Value.Check(OrgIdentitySchema, { ...validOrg, constitutional_hash: 'a'.repeat(64) })).toBe(false);
+  });
+
+  it('rejects a constitutional_hash with non-hex characters', () => {
+    expect(Value.Check(OrgIdentitySchema, { ...validOrg, constitutional_hash: 'sha256:' + 'Z'.repeat(64) })).toBe(false);
+  });
+
+  // --- Mutation 4: missing required field ---
+  it('rejects when org_id is missing', () => {
+    const { org_id: _omit, ...rest } = validOrg;
+    expect(Value.Check(OrgIdentitySchema, rest)).toBe(false);
+  });
+
+  it('rejects when constitutional_hash is missing', () => {
+    const { constitutional_hash: _omit, ...rest } = validOrg;
+    expect(Value.Check(OrgIdentitySchema, rest)).toBe(false);
+  });
+
+  // --- Mutation 5: additional property ---
+  it('rejects an unexpected additional property at the root', () => {
+    expect(Value.Check(OrgIdentitySchema, { ...validOrg, extra: true })).toBe(false);
+  });
+
+  // --- Mutation 6: invalid org_id format ---
+  it('rejects when org_id is not a UUID', () => {
+    expect(Value.Check(OrgIdentitySchema, { ...validOrg, org_id: 'not-a-uuid' })).toBe(false);
+  });
+
+  // --- Mutation 7: created_at / updated_at not ISO 8601 ---
+  it('rejects when created_at is not an ISO 8601 date-time', () => {
+    expect(Value.Check(OrgIdentitySchema, { ...validOrg, created_at: '2026-05-05' })).toBe(false);
+  });
+});

--- a/tests/schemas/org-representative-delegation.test.ts
+++ b/tests/schemas/org-representative-delegation.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for OrgRepresentativeDelegationSchema (FR-B2, v8.4.0).
+ *
+ * Validates schema shape, required fields, and ≥5 mutation classes including
+ * chain depth boundary (>20), the granted_by union (UUID OR genesis sentinel),
+ * and Ed25519 signature pattern enforcement.
+ *
+ * Cross-field rules ORD-1..3 are enforced by the constraint file landing in
+ * PR-A1.4; signature verification (ORD-1) and revocation lifecycle (ORD-2)
+ * are runtime-deferred per NF-1. This suite validates only TypeBox-level
+ * schema rules.
+ */
+import { describe, it, expect } from 'vitest';
+import { Value } from '@sinclair/typebox/value';
+import {
+  OrgRepresentativeDelegationSchema,
+  ORG_DELEGATION_GENESIS_SENTINEL,
+  type OrgRepresentativeDelegation,
+} from '../../src/governance/org-representative-delegation.js';
+import type { AgentIdentity } from '../../src/schemas/agent-identity.js';
+import '../../src/validators/index.js';
+
+const validAgent: AgentIdentity = {
+  agent_id: 'agent-rep',
+  display_name: 'Representative',
+  agent_type: 'human',
+  capabilities: ['governance'],
+  trust_scopes: {
+    scopes: {
+      billing: 'trusted',
+      governance: 'trusted',
+      inference: 'trusted',
+      delegation: 'trusted',
+      audit: 'trusted',
+      composition: 'trusted',
+    },
+    default_level: 'trusted',
+  },
+  delegation_authority: ['invoke'],
+  max_delegation_depth: 2,
+  governance_weight: 0.5,
+  contract_version: '8.4.0',
+};
+
+const ED25519_SIG = 'ed25519:' + 'A'.repeat(86);
+const ED25519_PUB = 'ed25519-pub:' + 'A'.repeat(43);
+
+const validDelegation: OrgRepresentativeDelegation = {
+  delegation_id: '550e8400-e29b-41d4-a716-446655440010',
+  org_id: '550e8400-e29b-41d4-a716-446655440000',
+  representative: validAgent,
+  capability_scope: { domain: 'governance', actions: ['vote', 'propose'] },
+  expiry: '2027-05-05T00:00:00Z',
+  granted_by: ORG_DELEGATION_GENESIS_SENTINEL,
+  chain_depth: 0,
+  signature: ED25519_SIG,
+  signed_by: ED25519_PUB,
+  signing_key_id: 'org-key-2026-05',
+  signing_algorithm: 'ed25519',
+  signed_at: '2026-05-05T00:01:00Z',
+  signing_context: {
+    audience: '550e8400-e29b-41d4-a716-446655440000',
+    scope: 'org-delegation/grant',
+    contract_version: '8.4.0',
+  },
+};
+
+describe('OrgRepresentativeDelegationSchema', () => {
+  it('validates a canonical fixture (genesis-rooted, depth 0)', () => {
+    expect(Value.Check(OrgRepresentativeDelegationSchema, validDelegation)).toBe(true);
+  });
+
+  it('validates a chained delegation with granted_by as a delegation_id UUID', () => {
+    const chained: OrgRepresentativeDelegation = {
+      ...validDelegation,
+      delegation_id: '550e8400-e29b-41d4-a716-446655440011',
+      granted_by: '550e8400-e29b-41d4-a716-446655440010',
+      chain_depth: 1,
+    };
+    expect(Value.Check(OrgRepresentativeDelegationSchema, chained)).toBe(true);
+  });
+
+  it('validates with optional revocation envelope present', () => {
+    const revoked: OrgRepresentativeDelegation = {
+      ...validDelegation,
+      revocation: {
+        revoked: true,
+        revoked_at: '2026-06-05T00:00:00Z',
+        revoked_by: 'agent-overseer',
+      },
+    };
+    expect(Value.Check(OrgRepresentativeDelegationSchema, revoked)).toBe(true);
+  });
+
+  it('has $id = OrgRepresentativeDelegation', () => {
+    expect(OrgRepresentativeDelegationSchema.$id).toBe('OrgRepresentativeDelegation');
+  });
+
+  it('declares x-cross-field-validated:true', () => {
+    expect((OrgRepresentativeDelegationSchema as { 'x-cross-field-validated'?: boolean })['x-cross-field-validated']).toBe(true);
+  });
+
+  it('exports the genesis sentinel as a stable literal', () => {
+    expect(ORG_DELEGATION_GENESIS_SENTINEL).toBe('genesis:org-public-key');
+  });
+
+  // --- Mutation 1: chain_depth boundary (> 20) ---
+  it('rejects chain_depth above the maximum (21)', () => {
+    expect(Value.Check(OrgRepresentativeDelegationSchema, { ...validDelegation, chain_depth: 21 })).toBe(false);
+  });
+
+  it('rejects chain_depth below the minimum (-1)', () => {
+    expect(Value.Check(OrgRepresentativeDelegationSchema, { ...validDelegation, chain_depth: -1 })).toBe(false);
+  });
+
+  // --- Mutation 2: signature pattern violation ---
+  it('rejects a signature without the ed25519: prefix', () => {
+    expect(Value.Check(OrgRepresentativeDelegationSchema, { ...validDelegation, signature: 'rsa:' + 'A'.repeat(86) })).toBe(false);
+  });
+
+  it('rejects a signed_by without the ed25519-pub: prefix', () => {
+    expect(Value.Check(OrgRepresentativeDelegationSchema, { ...validDelegation, signed_by: 'rsa-pub:' + 'A'.repeat(43) })).toBe(false);
+  });
+
+  // --- Mutation 3: signing_algorithm not pinned to 'ed25519' ---
+  it('rejects a signing_algorithm other than "ed25519"', () => {
+    expect(Value.Check(OrgRepresentativeDelegationSchema, { ...validDelegation, signing_algorithm: 'rsa' })).toBe(false);
+  });
+
+  // --- Mutation 4: granted_by neither UUID nor genesis sentinel ---
+  it('rejects granted_by that is neither a UUID nor the genesis sentinel', () => {
+    expect(Value.Check(OrgRepresentativeDelegationSchema, { ...validDelegation, granted_by: 'genesis:wrong-key' })).toBe(false);
+  });
+
+  it('rejects granted_by with a malformed UUID', () => {
+    expect(Value.Check(OrgRepresentativeDelegationSchema, { ...validDelegation, granted_by: 'not-a-uuid' })).toBe(false);
+  });
+
+  // --- Mutation 5: signing_context contract_version not semver ---
+  it('rejects a signing_context.contract_version that is not semver-shaped', () => {
+    const mutated = {
+      ...validDelegation,
+      signing_context: { ...validDelegation.signing_context, contract_version: '8.4' },
+    };
+    expect(Value.Check(OrgRepresentativeDelegationSchema, mutated)).toBe(false);
+  });
+
+  // --- Mutation 6: missing required field ---
+  it('rejects when delegation_id is missing', () => {
+    const { delegation_id: _omit, ...rest } = validDelegation;
+    expect(Value.Check(OrgRepresentativeDelegationSchema, rest)).toBe(false);
+  });
+
+  it('rejects when signing_context is missing', () => {
+    const { signing_context: _omit, ...rest } = validDelegation;
+    expect(Value.Check(OrgRepresentativeDelegationSchema, rest)).toBe(false);
+  });
+
+  // --- Mutation 7: additional property ---
+  it('rejects an unexpected additional property at the root', () => {
+    expect(Value.Check(OrgRepresentativeDelegationSchema, { ...validDelegation, extra: true })).toBe(false);
+  });
+
+  // --- Mutation 8: revocation envelope shape (additional property) ---
+  it('rejects an unexpected additional property inside revocation', () => {
+    const mutated = {
+      ...validDelegation,
+      revocation: {
+        revoked: true,
+        revoked_at: '2026-06-05T00:00:00Z',
+        revoked_by: 'agent-overseer',
+        smuggled: 'value',
+      },
+    };
+    expect(Value.Check(OrgRepresentativeDelegationSchema, mutated)).toBe(false);
+  });
+});

--- a/tests/schemas/org-representative-delegation.test.ts
+++ b/tests/schemas/org-representative-delegation.test.ts
@@ -174,4 +174,17 @@ describe('OrgRepresentativeDelegationSchema', () => {
     };
     expect(Value.Check(OrgRepresentativeDelegationSchema, mutated)).toBe(false);
   });
+
+  // --- Mutation 9: revocation.revoked pinned to literal true (envelope-presence semantics) ---
+  it('rejects revocation.revoked = false (must be literal true when envelope is present)', () => {
+    const mutated = {
+      ...validDelegation,
+      revocation: {
+        revoked: false,
+        revoked_at: '2026-06-05T00:00:00Z',
+        revoked_by: 'agent-overseer',
+      },
+    };
+    expect(Value.Check(OrgRepresentativeDelegationSchema, mutated)).toBe(false);
+  });
 });

--- a/tests/schemas/succession-policy.test.ts
+++ b/tests/schemas/succession-policy.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for SuccessionPolicySchema (FR-B3, v8.4.0).
+ *
+ * Validates schema shape, required fields, and ≥5 mutation classes including
+ * threshold/cooldown bounds and the OQ4 resolution (no `self_removal_allowed`
+ * field — its absence is enforced by `additionalProperties: false`).
+ *
+ * Cross-field rules SP-1 (asymmetric ladder amend ≥ rotate ≥ add ≥ remove)
+ * and SP-2 (non-decreasing cooldown) are enforced by the constraint file
+ * landing in PR-A1.4; this suite validates only TypeBox-level schema rules.
+ */
+import { describe, it, expect } from 'vitest';
+import { Value } from '@sinclair/typebox/value';
+import {
+  SuccessionPolicySchema,
+  type SuccessionPolicy,
+} from '../../src/governance/succession-policy.js';
+import '../../src/validators/index.js';
+
+const validPolicy: SuccessionPolicy = {
+  policy_id: '550e8400-e29b-41d4-a716-446655440020',
+  org_id: '550e8400-e29b-41d4-a716-446655440000',
+  amend: { threshold: 0.9, cooldown_seconds: 86400 },
+  rotate: { threshold: 0.75, cooldown_seconds: 43200 },
+  add: { threshold: 0.6, cooldown_seconds: 21600 },
+  remove: { threshold: 0.5, cooldown_seconds: 10800 },
+  effective_at: '2026-05-05T00:00:00Z',
+};
+
+describe('SuccessionPolicySchema', () => {
+  it('validates a canonical fixture (asymmetric ladder + non-decreasing cooldown)', () => {
+    expect(Value.Check(SuccessionPolicySchema, validPolicy)).toBe(true);
+  });
+
+  it('has $id = SuccessionPolicy', () => {
+    expect(SuccessionPolicySchema.$id).toBe('SuccessionPolicy');
+  });
+
+  it('declares x-cross-field-validated:true', () => {
+    expect((SuccessionPolicySchema as { 'x-cross-field-validated'?: boolean })['x-cross-field-validated']).toBe(true);
+  });
+
+  it('declares additionalProperties:false', () => {
+    expect((SuccessionPolicySchema as { additionalProperties?: boolean }).additionalProperties).toBe(false);
+  });
+
+  // --- Mutation 1: threshold above the [0, 1] range ---
+  it('rejects amend.threshold above 1', () => {
+    expect(Value.Check(SuccessionPolicySchema, { ...validPolicy, amend: { threshold: 1.1, cooldown_seconds: 86400 } })).toBe(false);
+  });
+
+  it('rejects rotate.threshold below 0', () => {
+    expect(Value.Check(SuccessionPolicySchema, { ...validPolicy, rotate: { threshold: -0.01, cooldown_seconds: 43200 } })).toBe(false);
+  });
+
+  // --- Mutation 2: cooldown_seconds below 0 ---
+  it('rejects add.cooldown_seconds below 0', () => {
+    expect(Value.Check(SuccessionPolicySchema, { ...validPolicy, add: { threshold: 0.6, cooldown_seconds: -1 } })).toBe(false);
+  });
+
+  it('rejects cooldown_seconds that is not an integer', () => {
+    expect(Value.Check(SuccessionPolicySchema, { ...validPolicy, remove: { threshold: 0.5, cooldown_seconds: 10800.5 } })).toBe(false);
+  });
+
+  // --- Mutation 3: missing required action ---
+  it('rejects when amend is missing', () => {
+    const { amend: _omit, ...rest } = validPolicy;
+    expect(Value.Check(SuccessionPolicySchema, rest)).toBe(false);
+  });
+
+  it('rejects when remove is missing', () => {
+    const { remove: _omit, ...rest } = validPolicy;
+    expect(Value.Check(SuccessionPolicySchema, rest)).toBe(false);
+  });
+
+  // --- Mutation 4: additional property at root (OQ4: no self_removal_allowed) ---
+  it('rejects a self_removal_allowed property (OQ4: not in schema)', () => {
+    expect(Value.Check(SuccessionPolicySchema, { ...validPolicy, self_removal_allowed: true })).toBe(false);
+  });
+
+  it('rejects an unexpected additional property at the root', () => {
+    expect(Value.Check(SuccessionPolicySchema, { ...validPolicy, extra: 1 })).toBe(false);
+  });
+
+  // --- Mutation 5: action rule with additional property ---
+  it('rejects an unexpected additional property inside an action rule', () => {
+    expect(
+      Value.Check(SuccessionPolicySchema, {
+        ...validPolicy,
+        amend: { threshold: 0.9, cooldown_seconds: 86400, smuggled: 'value' },
+      }),
+    ).toBe(false);
+  });
+
+  // --- Mutation 6: threshold wrong type ---
+  it('rejects a threshold given as a string', () => {
+    expect(
+      Value.Check(SuccessionPolicySchema, {
+        ...validPolicy,
+        amend: { threshold: '0.9', cooldown_seconds: 86400 },
+      }),
+    ).toBe(false);
+  });
+
+  // --- Mutation 7: invalid policy_id format ---
+  it('rejects when policy_id is not a UUID', () => {
+    expect(Value.Check(SuccessionPolicySchema, { ...validPolicy, policy_id: 'not-a-uuid' })).toBe(false);
+  });
+
+  // --- Mutation 8: effective_at not ISO 8601 ---
+  it('rejects when effective_at is not an ISO 8601 date-time', () => {
+    expect(Value.Check(SuccessionPolicySchema, { ...validPolicy, effective_at: '2026-05-05' })).toBe(false);
+  });
+
+  // --- Cross-field documentation note (SP-1, SP-2 deferred to PR-A1.4) ---
+  it('accepts an asymmetric-ladder violation at the schema level (cross-field rule SP-1 deferred to PR-A1.4)', () => {
+    // amend.threshold (0.5) < rotate.threshold (0.9) — violates SP-1, but caught
+    // only by the constraint file in PR-A1.4. The schema itself does not enforce
+    // cross-field comparisons; this test pins the boundary.
+    const violator = {
+      ...validPolicy,
+      amend: { threshold: 0.5, cooldown_seconds: 86400 },
+      rotate: { threshold: 0.9, cooldown_seconds: 43200 },
+    };
+    expect(Value.Check(SuccessionPolicySchema, violator)).toBe(true);
+  });
+});

--- a/tests/vectors/version-bump.test.ts
+++ b/tests/vectors/version-bump.test.ts
@@ -246,9 +246,9 @@ describe('version bump', () => {
     const index = JSON.parse(readFileSync(join(root, 'schemas', 'index.json'), 'utf-8'));
     // Hardcoded count is a per-release snapshot — the assertion intentionally
     // tightens after each additive PR so accidental schema removal is caught.
-    // Count = 206 after PR-A1.1 (4 deliberation top-levels + SigningContext +
-    // auto-registered sub-schemas with $id). Subsequent additive PRs update
-    // this number; v8.4.0 release reconciliation lands the final count.
-    expect(index.schemas).toHaveLength(206);
+    // Count = 209 after PR-A1.2 (PR-A1.1's 206 + 3 OrgOverseer schemas).
+    // Subsequent additive PRs update this number; v8.4.0 release reconciliation
+    // (PR-A1.6) lands the final count.
+    expect(index.schemas).toHaveLength(209);
   });
 });


### PR DESCRIPTION
## Summary

Lands the 3 OrgOverseer TypeBox schemas (FR-B1..FR-B3 from Issue #61):

- **`OrgIdentitySchema`** (FR-B1) — cold-storage `org_public_key` + active representative `AgentIdentity` snapshot (≥1 per SP-007) + `constitutional_hash`. Minimum-rep invariant expressed at TypeBox layer (`minItems: 1`) and as constraint OI-1 (PR-A1.4).
- **`OrgRepresentativeDelegationSchema`** (FR-B2) — append-only delegation log, Ed25519-signed under a `signing_context` envelope (audience = `org_id`, scope = `'org-delegation/grant'` or `'/revoke'`, contract_version) for cross-org / cross-lifecycle replay protection. Reuses `SigningContextSchema` from PR-A1.1 for shape parity with `PanelVerdict`. Chain depth bounded to 20; `granted_by` is either a `delegation_id` UUID or the genesis sentinel literal `"genesis:org-public-key"` (stable cross-runner per SDD §3.6 ORD-3).
- **`SuccessionPolicySchema`** (FR-B3) — constitutional thresholds for `amend`/`rotate`/`add`/`remove`, each with `threshold` (quorum fraction in [0,1]) + `cooldown_seconds`. Per OQ4 resolution, no `self_removal_allowed` field (the SP-007 invariant on `OrgIdentity` blocks rep-zeroing writes).

## Stacked on PR-A1.1

This PR is stacked on `feat/v8.4.0-pr-a1.1-deliberation` (PR #62). The `OrgRepresentativeDelegation.signing_context` field requires the shared `SigningContextSchema` exported by PR-A1.1; branching from `main` would have forced a duplicate definition.

When PR-A1.1 merges, GitHub will automatically retarget this PR to `main` and the deliberation-set commits will drop out of the diff naturally. The base pointer is set to PR-A1.1's branch so the diff visible during review shows **only** sprint-2 changes (3 schemas + barrel + validators + generator + 3 test files + revocation literal-true fix).

## Library/Runtime Boundary (NF-1)

| Constraint | Layer | Notes |
|---|---|---|
| ORD-1 (Ed25519 signature verification) | runtime-deferred | Cryptographic execution is consumer-side. Schema declares signature *shape* via pattern. |
| ORD-2 (revocation lifecycle append-only) | runtime-deferred (cross-record) + schema-subsumed (single-record) | `revocation.revoked` is `Type.Literal(true)` so envelope-presence and boolean-value cannot disagree. The cross-record "no later record may reset to absent" obligation remains consumer-side. |
| ORD-3 (chain validity + depth bound) | library, via `is_valid_dag` (PR-A1.3) | `chain_depth` upper bound (20) enforced at TypeBox layer; cycle detection is the constraint engine's job. |
| SP-1 (asymmetric ladder amend ≥ rotate ≥ add ≥ remove) | constraint file (PR-A1.4) | Cross-field rule, not schema-level. |
| SP-2 (non-decreasing cooldown) | constraint file (PR-A1.4) | Same. |

All three schemas carry `'x-cross-field-validated': true` to advertise that they require constraint-engine validation beyond TypeBox.

## Test Plan

- [x] `npm run typecheck` — green
- [x] `npm run test -- tests/schemas/{org-identity,org-representative-delegation,succession-policy}.test.ts` — 49 tests pass (canonical + ≥5 mutation classes per schema, plus `revocation.revoked: false` rejection)
- [x] `npm run build` — green
- [x] `npm run schema:generate` — emits `schemas/{org-identity,org-representative-delegation,succession-policy}.schema.json`
- [x] `npm run semver:check` — green
- [⏸] Full test suite — 6741/6743 pass; 2 pre-existing failures in `tests/vectors/version-bump.test.ts` (CONTRACT_VERSION 8.3.0 vs package.json 8.3.1; stale schema-count assertion 191 vs actual 208). Both are PR-A1.6 territory; identical acceptance was merged on PR-A1.1 (`cef5f4e0`).
- [x] ADR-001 collision check — no root-barrel name conflicts; new schemas exported from `@0xhoneyjar/loa-hounfour/governance` only.
- [x] ADR-007 spread pattern — N/A (sprint-2 schemas don't compose `GOVERNED_RESOURCE_FIELDS`; SDD §3.4 doesn't list governance-resource fields on these three schemas).

## Reviewer Notes

Two BLOCKING findings from cross-model adversarial review (cycles 1+2):

1. **DISS-001 — `revocation.revoked` ambiguity** → **FIXED** in commit `8e51acb0`. Pinned to `Type.Literal(true)` (JSON Schema `const: true`); added explicit rejection test for `revoked: false`.
2. **DISS-002/DISS-003 — schema artifacts published under 8.3.0 namespace** → **ACCEPTED-DEFERRED**. PR-A1.6 bumps `CONTRACT_VERSION`. Identical accepted-deferral merged on PR-A1.1.

Cross-model security dissenter (audit phase) found 0 findings.

## Acceptance Criteria — Final Status

- [x] AC-2.1: All 3 schemas compile via TypeBox; JSON Schema 2020-12 generated.
- [x] AC-2.2: `governance/index.ts` re-exports the 3 new schemas with their types.
- [x] AC-2.3: `validators/index.ts` registers the 3 new schemas.
- [x] AC-2.4: `validate(<Schema>, fixture)` returns valid for canonical + invalid for ≥5 mutation classes per schema.
- [x] AC-2.5: No collisions with existing root-level exports (per ADR-001).
- [⏸] AC-2.6: Full toolchain green except pre-existing version-bump failure (PR-A1.6 territory).
- [x] AC-2.7: No `additionalProperties: false` regressions.
- [x] AC-2.8: Anonymization clean.

## Reviewer Routing

- @janitooor (default)
- governance-schema reviewer (per RFC routing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)