### PR TITLE
chore(v8.4.0): tighten contract_version pattern + register 7 v8.4.0 cross-field validator stubs

### DIFF
--- a/src/governance/deliberation-dissent.ts
+++ b/src/governance/deliberation-dissent.ts
@@ -53,8 +53,8 @@ export const DeliberationDissentSchema = Type.Object(
       description: 'ISO 8601 timestamp at which the dissent was raised.',
     }),
     contract_version: Type.String({
-      pattern: '^\\d+\\.\\d+\\.\\d+$',
-      description: 'Protocol contract version pinned at dissent time.',
+      pattern: '^[1-9][0-9]*\\.[0-9]+\\.[0-9]+$',
+      description: 'Protocol contract version pinned at dissent time. Major version must be >= 1; leading-zero majors are rejected per SDD section 3.6.',
     }),
   },
   {

--- a/src/governance/panel-decision-artifact.ts
+++ b/src/governance/panel-decision-artifact.ts
@@ -193,8 +193,8 @@ export const PanelDecisionArtifactSchema = Type.Object(
       description: 'ISO 8601 / RFC 3339 creation timestamp.',
     }),
     contract_version: Type.String({
-      pattern: '^\\d+\\.\\d+\\.\\d+$',
-      description: 'Protocol contract version pinned at artifact creation.',
+      pattern: '^[1-9][0-9]*\\.[0-9]+\\.[0-9]+$',
+      description: 'Protocol contract version pinned at artifact creation. Major version must be >= 1; leading-zero majors are rejected per SDD section 3.6.',
     }),
   },
   {

--- a/src/governance/signing-context.ts
+++ b/src/governance/signing-context.ts
@@ -23,8 +23,8 @@ export const SigningContextSchema = Type.Object(
       description: 'Deliberation- or lifecycle-context binding (e.g., "panel-v1/security-review", "org-delegation/grant").',
     }),
     contract_version: Type.String({
-      pattern: '^\\d+\\.\\d+\\.\\d+$',
-      description: 'Semver-formatted protocol contract version pinned to the signing event.',
+      pattern: '^[1-9][0-9]*\\.[0-9]+\\.[0-9]+$',
+      description: 'Semver-formatted protocol contract version pinned to the signing event. Major version must be >= 1; leading-zero majors are rejected per SDD section 3.6 PV-4.',
     }),
   },
   {

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -845,6 +845,42 @@ registerCrossFieldValidator('AuditTrailEntry', (data) => {
   return errors.length > 0 ? { valid: false, errors, warnings } : { valid: true, errors: [], warnings };
 });
 
+// --- v8.4.0 — Deliberation set + OrgOverseer constraint-file-only registrations ---
+//
+// The substantive cross-field surface for these seven schemas is the
+// constraint-file rule set in `constraints/<SchemaName>.constraints.json`,
+// not a TypeScript-resident validator function. The stubs below register the
+// schema $ids in `crossFieldRegistry` so that:
+//   * `getCrossFieldValidatorSchemas()` returns them, allowing
+//     `npm run check:constraints` to detect that a constraint file exists for
+//     each of these schemas (closes the "constraint file for X does not match
+//     any registered schema" warning for the v8.4.0 schemas);
+//   * the registry shape stays uniform across schemas with mixed validation
+//     surfaces (TS-resident validators for transactional flows like
+//     `BillingEntry`; constraint-file-only validators for declarative
+//     contract sets like the deliberation primitives).
+//
+// Returning `{ valid: true, errors: [], warnings: [] }` is honest: the TS
+// pipeline does NOT enforce these rules — consumers MUST evaluate the
+// constraint files via `evaluateConstraint(...)` (or the equivalent
+// cross-language runner) to enforce PDA-1..5, PV-1..4, DD-1..2, CSR-1, OI-1,
+// ORD-3, SP-1..2. ORD-1 and ORD-2 carry their consumer obligation in the
+// UnverifiedObligationsManifest emitted at validate() time per SDD section 5.8.
+
+const constraintFileOnlyValidator: CrossFieldValidator = () => ({
+  valid: true,
+  errors: [],
+  warnings: [],
+});
+
+registerCrossFieldValidator('PanelDecisionArtifact', constraintFileOnlyValidator);
+registerCrossFieldValidator('PanelVerdict', constraintFileOnlyValidator);
+registerCrossFieldValidator('DeliberationDissent', constraintFileOnlyValidator);
+registerCrossFieldValidator('CrossScoreReport', constraintFileOnlyValidator);
+registerCrossFieldValidator('OrgIdentity', constraintFileOnlyValidator);
+registerCrossFieldValidator('OrgRepresentativeDelegation', constraintFileOnlyValidator);
+registerCrossFieldValidator('SuccessionPolicy', constraintFileOnlyValidator);
+
 /**
  * Returns schema $ids that have registered cross-field validators.
  * Enables consumers to discover which schemas benefit from cross-field validation.

--- a/tests/cross-field/discoverability.test.ts
+++ b/tests/cross-field/discoverability.test.ts
@@ -54,6 +54,15 @@ describe('getCrossFieldValidatorSchemas()', () => {
     'AgentCapacityReservation',
     // v5.2.0 — Audit Trail
     'AuditTrailEntry',
+    // v8.4.0 — Deliberation set + OrgOverseer (constraint-file-only validators;
+    // substantive cross-field surface is constraints/<SchemaName>.constraints.json)
+    'PanelDecisionArtifact',
+    'PanelVerdict',
+    'DeliberationDissent',
+    'CrossScoreReport',
+    'OrgIdentity',
+    'OrgRepresentativeDelegation',
+    'SuccessionPolicy',
   ];
 
   it('returns an array of strings', () => {


### PR DESCRIPTION
Two follow-ups absorbed from the PR #65 (PR-A1.4) iter-1 review's LOW-severity findings (F-5, F-6). Both were called out as "post-merge follow-up, not iter-2 scope" by the reviewer; landing them here as a focused chore PR keeps the original sprint PR clean and the follow-up auditable on its own.

## F-5 — Tighten `contract_version` pattern on the v8.4.0 schemas

`SigningContextSchema.contract_version`, `PanelDecisionArtifactSchema.contract_version`, and `DeliberationDissentSchema.contract_version` previously used `^\d+\.\d+\.\d+$` — permissive of `0.x.y` and `01.2.3`. SDD section 3.6 PV-4 specifies `^[1-9][0-9]*\.[0-9]+\.[0-9]+$` (major must be ≥ 1, no leading-zero majors). The PV-4 evaluation_note in `constraints/PanelVerdict.constraints.json` already states "well-formed semver pattern is enforced at the schema layer", so the schema pattern needs to match the SDD's pattern verbatim for cross-runner conformance.

Tightening a regex pattern is technically a behavioral change, but accepting `0.x.y` was never the intent and no test fixtures or vectors use leading-zero majors for `contract_version` (verified via `grep` across `tests/` and `vectors/` before applying — the single `0.1.0` match is in `tests/vectors/model-provider-spec.test.ts:265` against an unrelated `version` field, not `contract_version`). Filed as fix-not-a-break.

Pre-existing schemas from earlier releases (`reputation-credential`, `event-subscription`, `delegation-tree`, etc.) retain the permissive pattern — those have shipped and tightening them is out of scope for this chore.

## F-6 — Register cross-field validator stubs for the 7 v8.4.0 schemas

Before this change, `getCrossFieldValidatorSchemas()` returned 22 schema `$id`s. None of the seven v8.4.0 schemas were registered, so `scripts/generate-constraints.ts --validate` reported "constraint file for X does not match any registered schema" for each of them — making AC-4.1 of the PR-A1.4 sprint plan ambiguous (per-file `OK:` lines pass, but the registry-coverage check exits 1).

The substantive cross-field surface for these seven schemas is the constraint-file rule set in `constraints/<SchemaName>.constraints.json`, not a TypeScript-resident validator function. The stubs registered here return `{ valid: true, errors: [], warnings: [] }` and carry an explanatory header noting that consumers MUST evaluate the constraint files via `evaluateConstraint(...)` (or the equivalent cross-language runner) to enforce PDA-1..5, PV-1..4, DD-1..2, CSR-1, OI-1, ORD-3, SP-1..2; ORD-1 and ORD-2 carry their consumer obligation in the `UnverifiedObligationsManifest` emitted at `validate()` time per SDD section 5.8.

Registering the stubs:
- Closes the v8.4.0 half of the AC-4.1 ambiguity from PR-A1.4 (the seven new schemas no longer trigger the "does not match any registered schema" warning in `npm run check:constraints`).
- Makes the registry shape uniform across schemas with mixed validation surfaces — TS-resident validators for transactional flows (`BillingEntry`, `EscrowEntry`, etc.); constraint-file-only validators for declarative contract sets (the deliberation primitives, the OrgOverseer schemas).

`tests/cross-field/discoverability.test.ts` extended with the seven new schema `\$id`s (now 53 cross-field discoverability cases, +7 from this commit).

## Deferred from PR-A1.4 iter-1, NOT in this PR

- **F-4** (chain_depth-vs-actual-reachability cross-check): a v8.4.x or v8.5.0 design conversation — either tighten SDD prose to say "asserts chain_depth bound; consumer reconciles asserted-vs-traversed depth at runtime per NF-1", or add a future ORD-4 marked `runtime-deferred` carrying the asserted-vs-actual obligation in the unverified-obligations manifest. Out of scope for this chore.

## Test Plan

- [ ] `npm run typecheck` — passes
- [ ] `npm run test` — 6954 passing across 250 test files (+7 from discoverability.test.ts)
- [ ] `npm run check:constraints` — the seven v8.4.0 schemas no longer appear in the failure list. Process exits 1 due to ambient pre-existing state on `main` from older constraint files that predate the registry hygiene push (e.g., `AgentIdentity`, `BasketComposition`, `TaskTypeCohort`); their cleanup is tracked separately.
- [ ] `npm run semver:check` — passes (baseline)
- [ ] Pollution invariant — clean (only the package's own `loa-hounfour.dev` domain reference appears in added lines)

## Files changed (5)

| File | Change |
|---|---|
| `src/governance/signing-context.ts` | `contract_version` pattern: `^\d+\.\d+\.\d+$` → `^[1-9][0-9]*\.[0-9]+\.[0-9]+$` |
| `src/governance/panel-decision-artifact.ts` | same pattern tightening |
| `src/governance/deliberation-dissent.ts` | same pattern tightening |
| `src/validators/index.ts` | seven new `registerCrossFieldValidator(...)` calls + a `constraintFileOnlyValidator` reusable stub function + a section-header comment block explaining the constraint-file-only validation pattern |
| `tests/cross-field/discoverability.test.ts` | seven new `$id`s in `expectedSchemas` (closes the +7 hardcoded-count delta) |

## Dependencies

- Inbound: PR-A1.1 / PR-A1.2 / PR-A1.3 / PR-A1.4 — all merged. This chore depends on the v8.4.0 schemas + constraint files being on `main`.
- Outbound: PR-A1.5 (vectors + cross-runner sweep) is unaffected — the pattern tightening will surface in any vector that shipped with a leading-zero major for `contract_version` (none expected, but PR-A1.5 will rebuild against this baseline). PR-A1.6 (version bump + docs + signed tag) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)