### PR TITLE
chore(v8.4.0): pin GitHub Packages registry in publishConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,13 @@
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/0xHoneyJar/loa-hounfour.git"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

Pins the GitHub Packages registry in `package.json`'s `publishConfig` so future `npm publish` runs land on `https://npm.pkg.github.com` without needing a local `.npmrc` scope mapping or `--registry` CLI override.

Also adds the `repository` field so the package page on GitHub Packages associates cleanly with the source repo (links to issues, releases, source code).

## Context

`@0xhoneyjar/loa-hounfour@8.4.0` was published to GitHub Packages on 2026-05-06 via the CLI using a transient local `.npmrc` for the scope mapping. This commit makes the registry destination explicit in the package metadata so:

- Future publishes don't depend on the publisher having the `.npmrc` set up.
- Consumers can see at a glance where the package ships.
- Mirrors the convention used by `hosaka-fm/dix` and `hosaka-fm/runtime`.

## Consumer-side setup (informational, no change required by this PR)

Consumers of `@0xhoneyjar/loa-hounfour` need a project-local or user-level `.npmrc` with:

```
@0xhoneyjar:registry=https://npm.pkg.github.com
//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
```

`${GITHUB_TOKEN}` must be a GitHub PAT with at least the `read:packages` scope. Same shape as existing `hosaka-fm/dix` and `hosaka-fm/runtime` consumer setups.

## Test plan

- [ ] Confirm `package.json` parses cleanly (CI's `pnpm install --frozen-lockfile` step exercises this).
- [ ] After merge, run `npm publish --dry-run` from a fresh checkout (no `.npmrc`) and confirm the dry-run resolves to `npm.pkg.github.com` via the new `publishConfig`.
- [ ] No source code changes; tests should remain at 7,120 / 7,120 PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)