### PR TITLE
chore(cycle-005): PR-A3.0 — kickoff + spec scaffolds

### DIFF
--- a/.github/workflows/pollution-check.yml
+++ b/.github/workflows/pollution-check.yml
@@ -26,16 +26,28 @@ jobs:
       - name: Determine diff base
         id: base
         run: |
+          set -euo pipefail
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             base="${{ github.event.pull_request.base.sha }}"
           else
-            # push-to-main: diff the current commit against its parent.
             base="${{ github.event.before }}"
-            # github.event.before is all-zeros on first commit to a new branch.
             if [[ "$base" == "0000000000000000000000000000000000000000" ]]; then
               base="$(git rev-parse HEAD~1 2>/dev/null || echo HEAD)"
             fi
           fi
+
+          # Validate base is reachable in the local clone. Force-pushes can
+          # leave `before` unreachable; fall back to merge-base against
+          # origin/main rather than silently passing.
+          if ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
+            echo "warn: diff base $base unreachable in this checkout — falling back to merge-base origin/main"
+            base="$(git merge-base origin/main HEAD 2>/dev/null || echo "")"
+            if [[ -z "$base" ]] || ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
+              echo "::error::Cannot resolve a valid diff base; refusing to silent-pass."
+              exit 1
+            fi
+          fi
+
           echo "diff_base=$base" >> "$GITHUB_OUTPUT"
           echo "Diff base: $base"
 
@@ -47,20 +59,25 @@ jobs:
           # for rationale (avoids false-positives on the npm scope substring).
           pattern='\bLoa\b|\b[Ss]pirals?\b|\b[Ss]imstim\b|\b[Ff]latline\b|\b[Bb]ridgebuilder\b|\b[Bb]utterfreezone\b|\b[Gg]rimoires?\b|\bbeads\b|\brun-mode\b|\balways-on-vps\b'
 
-          # Diff content-bearing lines only; exclude --- / +++ headers.
-          diff_output="$(git diff --no-color "$base"...HEAD 2>/dev/null || true)"
+          # Fail loud if git diff itself fails — `|| true` would mask a real
+          # error and produce a silent green.
+          diff_output="$(git diff --no-color "$base"...HEAD)"
+
+          # Inspect ADDITIONS only (lines starting with `+`, excluding `+++`
+          # file headers). Deletions are exempt so cleanup commits that
+          # remove a previously-introduced term aren't blocked.
           forbidden="$(printf '%s\n' "$diff_output" \
-            | grep -E '^[+-]' \
-            | grep -vE '^(---|\+\+\+)' \
+            | grep -E '^\+' \
+            | grep -vE '^\+\+\+' \
             | grep -E "$pattern" \
             || true)"
 
           if [[ -n "$forbidden" ]]; then
-            echo "::error::pollution-grep: committed diff contains forbidden framework-internal term(s)."
+            echo "::error::pollution-grep: committed diff adds forbidden framework-internal term(s)."
             echo "$forbidden" | head -50
             echo ""
-            echo "The committed surface must contain ZERO references to framework-internal concepts."
+            echo "The committed surface must contain ZERO net additions of framework-internal concepts."
             exit 1
           fi
 
-          echo "OK: committed diff clean of pollution terms."
+          echo "OK: committed diff clean of pollution-term additions."

--- a/.github/workflows/pollution-check.yml
+++ b/.github/workflows/pollution-check.yml
@@ -1,0 +1,66 @@
+name: pollution-check
+
+# Pollution-invariant CI enforcement — CT-13 from cycle-005 RC1 register.
+# The local pre-commit hook (scripts/install-hooks.sh) is fast feedback for
+# the maintainer; this workflow is the binding gate that catches contributors
+# who don't have the hook installed.
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  pollution-check:
+    name: pollution-grep on committed diff
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (with full history for diff base)
+        uses: actions/checkout@v4
+        with:
+          # Need at least 2 commits so we can diff against the merge base on
+          # pull_request, OR the previous commit on push-to-main.
+          fetch-depth: 0
+
+      - name: Determine diff base
+        id: base
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base="${{ github.event.pull_request.base.sha }}"
+          else
+            # push-to-main: diff the current commit against its parent.
+            base="${{ github.event.before }}"
+            # github.event.before is all-zeros on first commit to a new branch.
+            if [[ "$base" == "0000000000000000000000000000000000000000" ]]; then
+              base="$(git rev-parse HEAD~1 2>/dev/null || echo HEAD)"
+            fi
+          fi
+          echo "diff_base=$base" >> "$GITHUB_OUTPUT"
+          echo "Diff base: $base"
+
+      - name: Run pollution grep
+        run: |
+          set -euo pipefail
+          base="${{ steps.base.outputs.diff_base }}"
+          # Word-boundary + case-distinction patterns — see scripts/install-hooks.sh
+          # for rationale (avoids false-positives on the npm scope substring).
+          pattern='\bLoa\b|\b[Ss]pirals?\b|\b[Ss]imstim\b|\b[Ff]latline\b|\b[Bb]ridgebuilder\b|\b[Bb]utterfreezone\b|\b[Gg]rimoires?\b|\bbeads\b|\brun-mode\b|\balways-on-vps\b'
+
+          # Diff content-bearing lines only; exclude --- / +++ headers.
+          diff_output="$(git diff --no-color "$base"...HEAD 2>/dev/null || true)"
+          forbidden="$(printf '%s\n' "$diff_output" \
+            | grep -E '^[+-]' \
+            | grep -vE '^(---|\+\+\+)' \
+            | grep -E "$pattern" \
+            || true)"
+
+          if [[ -n "$forbidden" ]]; then
+            echo "::error::pollution-grep: committed diff contains forbidden framework-internal term(s)."
+            echo "$forbidden" | head -50
+            echo ""
+            echo "The committed surface must contain ZERO references to framework-internal concepts."
+            exit 1
+          fi
+
+          echo "OK: committed diff clean of pollution terms."

--- a/docs/architecture/canonicalization-spec-v8.6.md
+++ b/docs/architecture/canonicalization-spec-v8.6.md
@@ -1,0 +1,124 @@
+# Canonicalization Spec — v8.6.0
+
+**Status**: Scaffold authored at PR-A3.0; expanded inline with each schema-shipping PR (A3.4, A3.5, A3.6) and finalized at PR-A3.12.
+**Authoring date**: 2026-05-08
+**Predecessors**: `docs/architecture/hashing-spec-freeze-v8.5.md` (v8.5.0 G3 hash-domain freeze)
+**Reference implementation**: `src/utilities/safe-canonicalize.ts` (re-exported from `@0xhoneyjar/loa-hounfour/integrity` under `@experimental` per ADR-010 carve-out)
+**ADR**: [ADR-010 — Class-vs-Policy Boundary](../adr/ADR-010-class-vs-policy-boundary.md)
+
+---
+
+## 1. Why this document exists
+
+cycle-005 ships several v8.6.0 schemas whose contracts depend on cross-language byte-identical canonicalization:
+
+- `PhaseCompletionEnvelopeSchema` (FR-B2) — 4 KB canonical-JSON cap (NFR-4); hash-chain integrity via `prev_envelope_hash`.
+- `OracleDigestSchema` (FR-B3) — 4 KB Telegram-variant size cap.
+- `PlanSignoffEnvelopeSchema` (FR-B9) — `plan_content_hash` is SHA-256 over the canonicalized concatenation of `{prd_md, sdd_md, sprint_md}`.
+- `PlanAmendmentRequestSchema` (FR-B10) — `parent_plan_hash` follows the same rule.
+- FR-C builtins (`nonce_unique_per_signer_window`, `sequence_monotonic_per_cluster`, `chain_validator_prev_hash`, `plan_content_hash_unchanged_since_signoff`) — operate on canonical-form inputs.
+
+Cross-language parity (NFR-3, hard pre-major-release gate) requires that TS, Python, Go, and Rust runners produce **byte-identical** output for the same input. RFC 8785 alone is not sufficient: it specifies key sorting, escape-minimal encoding, and Unicode handling at the JSON layer, but says nothing about Unicode normalization, decimal precision normalization beyond IEEE 754 round-tripping, or input pre-processing. This document is the normative complement.
+
+## 2. Algorithm
+
+```
+canonicalize(value: any) -> bytes:
+  v0 = nfc_normalize_strings_recursive(value)        // §3
+  v1 = drop_undefined_and_function_values(v0)        // §4
+  v2 = sort_object_keys_recursive(v1)                // §5
+  s  = rfc8785_serialize(v2)                         // §6
+  b  = utf8_encode(s)                                // §7
+  if len(b) > MAX_BYTES_DEFAULT (100_000): error      // §8
+  return b
+```
+
+`hash(value: any) -> "sha256:<hex>"`:
+```
+b = canonicalize(value)
+h = sha256(b)
+return "sha256:" + lowercase_hex(h)
+```
+
+## 3. NFC normalization
+
+Every string value (object key OR string value) at every depth is normalized to **Unicode NFC** before any other step. Rationale: an NFD-form string and an NFC-form string with identical visible content produce different UTF-8 byte sequences and therefore different SHA-256 hashes — a class of cross-platform mismatch the v8.5.0 freeze identified and the FR-C/FR-B9 plan-hash builtin would otherwise inherit.
+
+Reference: TR15 NFC. Implementations:
+- TypeScript: `String.prototype.normalize('NFC')`
+- Python: `unicodedata.normalize('NFC', s)`
+- Go: `golang.org/x/text/unicode/norm.NFC.String(s)`
+- Rust: `unicode-normalization` crate, `s.nfc().collect::<String>()`
+
+NFC is applied **before** RFC 8785 serialization, not after, so the canonical bytes reflect the normalized form.
+
+## 4. Drop undefined / function values
+
+JavaScript-specific input shapes contain `undefined` and `Function` values that JSON cannot represent. Other runtimes will not produce these inputs, so the normalization is a no-op for non-JS callers. For JS callers:
+
+- Object keys whose value is `undefined` or a `Function` are removed (parallel to `JSON.stringify`).
+- Array slots holding `undefined` become `null` (parallel to `JSON.stringify`).
+- Array slots holding `Function` become `null`.
+
+This step preserves shape parity with `JSON.stringify` output. The reference TS implementation handles this; non-TS runners producing JSON-clean inputs need no equivalent.
+
+## 5. Object key ordering
+
+Within each object, keys are sorted **lexicographically by Unicode code point** (NOT by UTF-16 code unit; NOT by collation). RFC 8785 §3.2.3 specifies this explicitly. Surrogates participate as their code-point value.
+
+Empty objects produce `{}`; the order rule is vacuous for them.
+
+## 6. RFC 8785 serialization
+
+After NFC + key-ordering, the value is serialized per RFC 8785 (JCS):
+
+- No insignificant whitespace.
+- Strings escape per RFC 8259 §7 *minimal* form: `"`, `\`, and `U+0000`..`U+001F` only. Solidus (`/`) is NOT escaped. Non-ASCII Unicode is emitted as raw UTF-8 (no `\uXXXX` escapes).
+- Numbers emit per ECMAScript `Number.prototype.toString` (which RFC 8785 §3.2.2.3 prescribes via JS-specific shortest-round-trip rules). Integers below 2^53 emit without exponent; finite non-integers may use `e±N`.
+- `true`, `false`, `null` are literals.
+
+Rationale: every runtime has a JCS implementation or a clear porting target.
+
+## 7. UTF-8 encoding
+
+The serialized JSON string is encoded as UTF-8 with no BOM, no leading/trailing whitespace, and no platform-specific line endings (no `\r\n`).
+
+## 8. Size cap
+
+Default `MAX_BYTES_DEFAULT = 100_000` (100 KB) per `SAFE_CANONICALIZE_DEFAULT_MAX_BYTES` (existing v8.5.0 constant, retained unchanged in cycle-005). Rationale: synchronous canonicalization is `O(n log n)`; SHA-256 over the bytes is `O(n)`; combined work at >100 KB blocks the Node.js event loop measurably on commodity hardware.
+
+Callers that genuinely need larger payloads override `maxBytes` and assume the back-pressure responsibility. The NFR-4 4 KB cap on individual envelope schemas (FR-B2, FR-B3) is enforced at the schema-refinement layer and is independent of this 100 KB outer cap.
+
+## 9. Plan-content-hash composition (FR-B9 / FR-C4)
+
+For `plan_content_hash` the canonical input is the **concatenation** of three documents in fixed order:
+
+```
+plan_canonical_bytes = canonicalize(prd_md_text) || "\n---\n" || canonicalize(sdd_md_text) || "\n---\n" || canonicalize(sprint_md_text)
+plan_content_hash = "sha256:" + lowercase_hex(sha256(plan_canonical_bytes))
+```
+
+Where `||` is byte concatenation, `\n---\n` is a fixed 5-byte separator (newline, three hyphens, newline), and `prd_md_text`/`sdd_md_text`/`sprint_md_text` are the **raw markdown contents** of the three files (NOT stripped of frontmatter; NOT normalized except by step §3 / §7).
+
+The separator prevents the boundary-collapse attack where one document ends with text another document begins with. The fixed order (PRD, SDD, sprint) is normative — alphabetical order would create a different hash and is forbidden.
+
+## 10. Cross-runner verification
+
+Cross-runner harness (FR-A2, ships in PR-A3.9) exercises this spec across TS + Python + Go + Rust runners against every v8.5.0 + v8.6.0 conformance vector. A divergence on any vector fails CI. Reference golden corpus is the TS `safeCanonicalize` output; non-TS runners reproduce it byte-exact.
+
+## 11. Versioning + drift
+
+This document is **frozen at v8.6.0 GA**. Future amendments require:
+- New ADR (or amendment to ADR-010) capturing the algorithm change
+- v9.0.0 MAJOR cycle (canonicalization changes are semver-non-additive — every v8.6.x consumer's stored hashes become invalid under any spec change)
+- A migration table mapping pre-change hashes to post-change hashes
+
+Pre-cycle-005 hash domains (v8.4.0 `signature.ts`, v7.11.0 `scoring-path-hash.ts`, v8.0.0 `audit-trail-hash.ts`) are explicitly **NOT** governed by this spec — they retain their original canonicalization for stored-hash stability per ADR-010 §exception. The class-vs-policy lint allowlist at `scripts/check-class-policy-boundary.allowlist.json` documents each.
+
+## 12. Open items (filled in by later PRs)
+
+- [ ] PR-A3.4: Add "PhaseCompletion canonicalization profile" subsection covering `nonce` base64url normalization + `sequence`/`signer_key_version` string-encoded integer canonical form.
+- [ ] PR-A3.5: Add "OracleDigest canonicalization profile" subsection covering Markdown body byte-counting (NOT canonicalization — the markdown stays raw; the field's NFR-4 cap measures UTF-8 bytes of the field value, not canonicalized form).
+- [ ] PR-A3.6: Add "PlanSignoff/Amendment canonicalization profile" subsection nailing down the `\n---\n` separator and the FR-C4 ledger-snapshot canonical form.
+- [ ] PR-A3.9: Add "Cross-runner conformance" appendix listing per-language NFC + JCS library bindings.
+- [ ] PR-A3.12: Lock-and-freeze; remove "scaffold" status; update `Status:` line to "Frozen at v8.6.0".

--- a/docs/architecture/canonicalization-spec-v8.6.md
+++ b/docs/architecture/canonicalization-spec-v8.6.md
@@ -91,16 +91,45 @@ Callers that genuinely need larger payloads override `maxBytes` and assume the b
 
 ## 9. Plan-content-hash composition (FR-B9 / FR-C4)
 
-For `plan_content_hash` the canonical input is the **concatenation** of three documents in fixed order:
+`plan_content_hash` is computed over the **byte-concatenation** of three markdown documents in fixed order. Markdown bodies are **NOT** passed through `canonicalize()` from §2 — that function is RFC 8785 JSON serialization, which would JSON-quote and escape-encode the entire markdown string and produce different bytes than the source file. Markdown is treated as opaque-text-with-NFC, not as a JSON value.
 
 ```
-plan_canonical_bytes = canonicalize(prd_md_text) || "\n---\n" || canonicalize(sdd_md_text) || "\n---\n" || canonicalize(sprint_md_text)
-plan_content_hash = "sha256:" + lowercase_hex(sha256(plan_canonical_bytes))
+nfc_utf8(s)              := utf8_bytes(nfc_normalize(s))                    // §3 + §7 applied to a string
+plan_canonical_bytes     := nfc_utf8(prd_md_text)
+                          || "\n---\n"
+                          || nfc_utf8(sdd_md_text)
+                          || "\n---\n"
+                          || nfc_utf8(sprint_md_text)
+plan_content_hash        := "sha256:" + lowercase_hex(sha256(plan_canonical_bytes))
 ```
 
-Where `||` is byte concatenation, `\n---\n` is a fixed 5-byte separator (newline, three hyphens, newline), and `prd_md_text`/`sdd_md_text`/`sprint_md_text` are the **raw markdown contents** of the three files (NOT stripped of frontmatter; NOT normalized except by step §3 / §7).
+Where:
+- `||` is byte concatenation.
+- `\n---\n` is a fixed 5-byte separator (`0x0A 0x2D 0x2D 0x2D 0x0A`). Three hyphens flanked by line-feeds — no carriage returns, no surrounding whitespace.
+- `prd_md_text` / `sdd_md_text` / `sprint_md_text` are the **raw markdown contents** of the three source files. Frontmatter is **not** stripped; trailing whitespace is **not** trimmed; line endings are **not** normalized beyond what step §7 forbids (no `\r\n` permitted in the source files themselves — emit a hard error if found).
 
 The separator prevents the boundary-collapse attack where one document ends with text another document begins with. The fixed order (PRD, SDD, sprint) is normative — alphabetical order would create a different hash and is forbidden.
+
+### 9.1 Worked example
+
+Given:
+- `prd_md_text = "# PRD\n"` (6 source bytes; NFC unchanged; UTF-8 `23 20 50 52 44 0A`)
+- `sdd_md_text = "# SDD\n"` (6 source bytes; UTF-8 `23 20 53 44 44 0A`)
+- `sprint_md_text = "# Sprint\n"` (9 source bytes; UTF-8 `23 20 53 70 72 69 6E 74 0A`)
+
+Then:
+```
+plan_canonical_bytes (hex):
+  23 20 50 52 44 0A                          // "# PRD\n"
+  0A 2D 2D 2D 0A                             // separator
+  23 20 53 44 44 0A                          // "# SDD\n"
+  0A 2D 2D 2D 0A                             // separator
+  23 20 53 70 72 69 6E 74 0A                 // "# Sprint\n"
+plan_canonical_bytes length: 31 bytes
+plan_content_hash: "sha256:" + lowercase_hex(sha256(<the 31 bytes above>))
+```
+
+A conformance vector under `vectors/plan-content-hash/v8.6.0/` will lock the resulting hash byte-exact at PR-A3.6 (FR-C4 builtin lands).
 
 ## 10. Cross-runner verification
 

--- a/docs/architecture/canonicalization-spec-v8.6.md
+++ b/docs/architecture/canonicalization-spec-v8.6.md
@@ -64,9 +64,11 @@ This step preserves shape parity with `JSON.stringify` output. The reference TS 
 
 ## 5. Object key ordering
 
-Within each object, keys are sorted **lexicographically by Unicode code point** (NOT by UTF-16 code unit; NOT by collation). RFC 8785 §3.2.3 specifies this explicitly. Surrogates participate as their code-point value.
+Within each object, keys are sorted **lexicographically by UTF-16 code unit of the JSON member name**, exactly as RFC 8785 §3.2.3 prescribes. For Basic Multilingual Plane characters (the vast majority of schema field names — ASCII, Latin-1, CJK ideographs ≤ U+FFFF) this ordering is identical to Unicode-code-point ordering. For characters above U+FFFF (e.g. emoji, ancient scripts, supplementary planes) the UTF-16 surrogate pair encoding governs order, NOT the underlying code point. Two strings whose only difference is a supplementary character may sort differently under UTF-16 code units than under code points; cross-language runners MUST reproduce the UTF-16-code-unit ordering byte-exact.
 
 Empty objects produce `{}`; the order rule is vacuous for them.
+
+Rationale: RFC 8785 chose UTF-16 code units for symmetry with ECMAScript string-comparison semantics (`String.prototype.localeCompare(other, undefined, { sensitivity: 'variant' })` semantics, plus JS array-sort default). Diverging from RFC 8785 here would break cross-language hash parity with any consumer that mirrored the published reference. Schema-author guidance: avoid non-BMP characters in JSON keys — the conformance window for cross-language UTF-16 ordering is hardest to defend at the surrogate boundary.
 
 ## 6. RFC 8785 serialization
 

--- a/scripts/check-class-policy-boundary.ts
+++ b/scripts/check-class-policy-boundary.ts
@@ -2,7 +2,7 @@
 /**
  * Class-vs-policy boundary structural lint (ADR-010).
  *
- * Five rules block accidental crossings of the boundary that ADR-010
+ * Six rules block accidental crossings of the boundary that ADR-010
  * draws between hounfour (ships shape) and consumers (ship authority):
  *
  *   RULE-1: src TS — exported function returning a union containing
@@ -17,11 +17,22 @@
  *           assertCryptoBearingFailsByDefault().
  *   RULE-5: src + tests TS — direct import from the 'canonicalize'
  *           package. Allowed only in src/utilities/safe-canonicalize.ts.
+ *   RULE-6: src/integrity/index.ts — re-exports whose names contain
+ *           "canonicaliz" must carry an @experimental annotation in the
+ *           comment block directly above the export, or be path-
+ *           allowlisted. Enforces CT-01 hybrid carve-out from cycle-005:
+ *           the existing safeCanonicalize re-export is allowed under
+ *           @experimental governance per
+ *           docs/architecture/canonicalization-spec-v8.6.md; any future
+ *           canonicalization helper re-export requires explicit ADR-010
+ *           deliberation. Hash-named re-exports (computeReqHash, etc.)
+ *           are stable utilities and deliberately NOT policed here.
  *
  * Allowlist: scripts/check-class-policy-boundary.allowlist.json.
  *
  * @see docs/adr/ADR-010-class-vs-policy-boundary.md
  * @since v8.5.0 (PR-A2.1; G1 + G3 additions per discovery run-2)
+ * @since v8.6.0 (PR-A3.0; RULE-6 added per CT-01 hybrid)
  */
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join, dirname, relative, posix } from 'node:path';
@@ -31,7 +42,7 @@ import { fileURLToPath } from 'node:url';
 // Public types — exported for tests/scripts/check-class-policy-boundary.test.ts
 // ---------------------------------------------------------------------------
 
-export type RuleId = 'RULE-1' | 'RULE-2' | 'RULE-3' | 'RULE-4' | 'RULE-5';
+export type RuleId = 'RULE-1' | 'RULE-2' | 'RULE-3' | 'RULE-4' | 'RULE-5' | 'RULE-6';
 
 export interface Violation {
   rule: RuleId;
@@ -56,6 +67,7 @@ export type AllowlistChecker = (rule: RuleId, path: string) => boolean;
 export const RULE_DOC_LINK = 'docs/adr/ADR-010-class-vs-policy-boundary.md';
 
 export const RULE_5_ALLOWED_PATH = posix.normalize('src/utilities/safe-canonicalize.ts');
+export const RULE_6_GUARDED_PATH = posix.normalize('src/integrity/index.ts');
 
 const RULE_FINDING_LINK: Record<RuleId, string> = {
   'RULE-1': RULE_DOC_LINK + ' (RULE-1 / no-go invariants 1, 3, 4)',
@@ -63,6 +75,7 @@ const RULE_FINDING_LINK: Record<RuleId, string> = {
   'RULE-3': RULE_DOC_LINK + ' (RULE-3 / naming hygiene)',
   'RULE-4': RULE_DOC_LINK + ' (RULE-4 / G1 safe-by-default crypto-bearing API)',
   'RULE-5': RULE_DOC_LINK + ' (RULE-5 / G3 canonicalize-cap bypass prevention)',
+  'RULE-6': RULE_DOC_LINK + ' (RULE-6 / CT-01 hybrid carve-out @experimental governance)',
 };
 
 // ---------------------------------------------------------------------------
@@ -98,6 +111,18 @@ const RULE_4_PATTERN = new RegExp(
 );
 
 const RULE_5_PATTERN = /(?:from|require\()\s*['"]canonicalize['"]/g;
+
+// RULE-6: re-exports from src/integrity/index.ts whose names match
+// /canonicaliz/i must have @experimental in the preceding comment block.
+// The pattern is narrow on purpose — CT-01 is specifically about
+// canonicalization-helper exports, not arbitrary hash-named symbols (which
+// are stable utilities under v8.5.x semver). Pattern matches the canonical
+// English-and-American spellings.
+const RULE_6_EXPORT_BLOCK_PATTERN = /^export\s+\{([^}]*)\}\s+from\s+['"][^'"]+['"]\s*;/gm;
+const RULE_6_BARRED_NAME_PATTERN = /canonicaliz/i;
+// How many characters back to scan for an @experimental tag in comments.
+// 1500 chars covers ~30 lines of comments comfortably.
+const RULE_6_COMMENT_LOOKBACK = 1500;
 
 // ---------------------------------------------------------------------------
 // Rule check functions — pure (path, content, allowed) → Violation[]
@@ -197,6 +222,61 @@ export function checkRule5(path: string, content: string, allowed: AllowlistChec
   return out;
 }
 
+// Strip a comma-separated `export { … }` body into individual binding names.
+// Handles `type` prefix and `as` aliases; preserves the source name (the part
+// the export refers to in the imported module).
+function parseExportNames(body: string): string[] {
+  return body
+    .split(',')
+    .map((part) => {
+      const trimmed = part.trim();
+      if (!trimmed) return '';
+      // `type Foo` -> `Foo`; `Foo as Bar` -> `Foo`.
+      const withoutType = trimmed.replace(/^type\s+/, '');
+      const sourceName = withoutType.split(/\s+as\s+/)[0].trim();
+      return sourceName;
+    })
+    .filter(Boolean);
+}
+
+// True if the slice of `content` ending at `endIndex` contains an
+// @experimental tag within the last RULE_6_COMMENT_LOOKBACK characters
+// AND that occurrence sits inside a line that begins with a comment marker.
+// Both `//` and `/** */` JSDoc forms count.
+function hasExperimentalAnnotationBefore(content: string, endIndex: number): boolean {
+  const start = Math.max(0, endIndex - RULE_6_COMMENT_LOOKBACK);
+  const window = content.slice(start, endIndex);
+  // Find @experimental occurrences and check each is on a comment line.
+  const tag = /@experimental\b/g;
+  let m: RegExpExecArray | null;
+  while ((m = tag.exec(window)) !== null) {
+    const before = window.slice(0, m.index);
+    if (isCommentLine(before)) return true;
+  }
+  return false;
+}
+
+export function checkRule6(path: string, content: string, allowed: AllowlistChecker): Violation[] {
+  if (path !== RULE_6_GUARDED_PATH) return [];
+  if (allowed('RULE-6', path)) return [];
+  const out: Violation[] = [];
+  let m: RegExpExecArray | null;
+  RULE_6_EXPORT_BLOCK_PATTERN.lastIndex = 0;
+  while ((m = RULE_6_EXPORT_BLOCK_PATTERN.exec(content)) !== null) {
+    const names = parseExportNames(m[1]);
+    const flagged = names.filter((n) => RULE_6_BARRED_NAME_PATTERN.test(n));
+    if (flagged.length === 0) continue;
+    if (hasExperimentalAnnotationBefore(content, m.index)) continue;
+    out.push({
+      rule: 'RULE-6',
+      path,
+      line: lineNumber(content, m.index),
+      excerpt: `export { ${flagged.join(', ')} } missing @experimental in preceding comment block`,
+    });
+  }
+  return out;
+}
+
 // ---------------------------------------------------------------------------
 // CLI driver — reads filesystem, applies rules, reports.
 // ---------------------------------------------------------------------------
@@ -249,6 +329,7 @@ if (isCli()) {
     violations.push(...checkRule1(path, content, allowed));
     violations.push(...checkRule2(path, content, allowed));
     violations.push(...checkRule5(path, content, allowed));
+    violations.push(...checkRule6(path, content, allowed));
   }
   for (const path of testFiles) {
     const content = readFileSync(join(repoRoot, path), 'utf-8');
@@ -263,7 +344,7 @@ if (isCli()) {
   if (violations.length === 0) {
     console.log(
       `OK: ${srcFiles.length} src/**/*.ts files, ${testFiles.length} tests/**/*.ts files, ` +
-        `${schemaFiles.length} schemas/*.json files clean across RULE-1..RULE-5.\n` +
+        `${schemaFiles.length} schemas/*.json files clean across RULE-1..RULE-6.\n` +
         `Allowlist: ${allowlist.entries.length} entries ` +
         `(see scripts/check-class-policy-boundary.allowlist.json).`,
     );

--- a/scripts/check-class-policy-boundary.ts
+++ b/scripts/check-class-policy-boundary.ts
@@ -285,8 +285,12 @@ function hasExperimentalAnnotationBefore(content: string, endIndex: number): boo
     inComment = true;
     if (/@experimental\b/.test(trimmed)) return true;
   }
-  // Reached top of file inside a comment run with no tag found.
-  return inComment ? false : false;
+  // Reached top of file scanning the adjacent comment run without finding
+  // the tag (or never entered a comment run at all). `inComment` tracks the
+  // distinction for any future caller that wants to differentiate them; for
+  // this rule both outcomes are "annotation absent".
+  void inComment;
+  return false;
 }
 
 export function checkRule6(path: string, content: string, allowed: AllowlistChecker): Violation[] {

--- a/scripts/check-class-policy-boundary.ts
+++ b/scripts/check-class-policy-boundary.ts
@@ -120,9 +120,13 @@ const RULE_5_PATTERN = /(?:from|require\()\s*['"]canonicalize['"]/g;
 // English-and-American spellings.
 const RULE_6_EXPORT_BLOCK_PATTERN = /^export\s+\{([^}]*)\}\s+from\s+['"][^'"]+['"]\s*;/gm;
 const RULE_6_BARRED_NAME_PATTERN = /canonicaliz/i;
-// How many characters back to scan for an @experimental tag in comments.
-// 1500 chars covers ~30 lines of comments comfortably.
-const RULE_6_COMMENT_LOOKBACK = 1500;
+// `export * from '...'` and `export * as ns from '...'` are forbidden in
+// the guarded path entirely: they bypass name-level inspection, so a
+// re-export targeting a module that contains a `canonicalize`-named symbol
+// (now or later) silently slips through RULE-6's annotation check. The
+// carve-out is for *individually named, individually annotated* symbols.
+const RULE_6_NAMESPACE_REEXPORT_PATTERN =
+  /^export\s+\*(?:\s+as\s+\w+)?\s+from\s+['"][^'"]+['"]\s*;/gm;
 
 // ---------------------------------------------------------------------------
 // Rule check functions — pure (path, content, allowed) → Violation[]
@@ -239,27 +243,68 @@ function parseExportNames(body: string): string[] {
     .filter(Boolean);
 }
 
-// True if the slice of `content` ending at `endIndex` contains an
-// @experimental tag within the last RULE_6_COMMENT_LOOKBACK characters
-// AND that occurrence sits inside a line that begins with a comment marker.
-// Both `//` and `/** */` JSDoc forms count.
+// True if the @experimental tag sits in a comment block that is **directly
+// adjacent** to the export at `endIndex` — i.e. only blank lines and other
+// comment lines separate the tag from the export. A distant unrelated
+// comment block elsewhere in the file does NOT authorize a re-export.
+//
+// We walk lines backward from the export. The first non-blank line we
+// encounter must be a comment line. Within the contiguous comment-line
+// run that immediately precedes the export, we look for `@experimental`.
+// As soon as we hit a line that is neither blank nor a comment, the
+// adjacent block has ended without finding the tag.
 function hasExperimentalAnnotationBefore(content: string, endIndex: number): boolean {
-  const start = Math.max(0, endIndex - RULE_6_COMMENT_LOOKBACK);
-  const window = content.slice(start, endIndex);
-  // Find @experimental occurrences and check each is on a comment line.
-  const tag = /@experimental\b/g;
-  let m: RegExpExecArray | null;
-  while ((m = tag.exec(window)) !== null) {
-    const before = window.slice(0, m.index);
-    if (isCommentLine(before)) return true;
+  const before = content.slice(0, endIndex);
+  const lines = before.split('\n');
+  // Drop the partial line at the export start (split returns an empty/partial
+  // tail when content ends mid-line; for adjacency we only care about the
+  // lines strictly above).
+  if (!lines[lines.length - 1].trim().length) lines.pop();
+  let inComment = false;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i];
+    const trimmed = line.trim();
+    if (trimmed.length === 0) {
+      // Blank line — allowed inside or between comment blocks; if we have
+      // not yet entered a comment block, treat as continuation.
+      continue;
+    }
+    const isComment =
+      trimmed.startsWith('//') ||
+      trimmed.startsWith('/*') ||
+      trimmed.startsWith('*/') ||
+      trimmed.startsWith('*');
+    if (!isComment) {
+      // First non-blank, non-comment line above — adjacency window closed.
+      return false;
+    }
+    inComment = true;
+    if (/@experimental\b/.test(trimmed)) return true;
   }
-  return false;
+  // Reached top of file inside a comment run with no tag found.
+  return inComment ? false : false;
 }
 
 export function checkRule6(path: string, content: string, allowed: AllowlistChecker): Violation[] {
   if (path !== RULE_6_GUARDED_PATH) return [];
   if (allowed('RULE-6', path)) return [];
   const out: Violation[] = [];
+
+  // (a) Namespace re-exports are unconditionally forbidden in the guarded
+  //     path — they bypass per-name inspection.
+  let nm: RegExpExecArray | null;
+  RULE_6_NAMESPACE_REEXPORT_PATTERN.lastIndex = 0;
+  while ((nm = RULE_6_NAMESPACE_REEXPORT_PATTERN.exec(content)) !== null) {
+    out.push({
+      rule: 'RULE-6',
+      path,
+      line: lineNumber(content, nm.index),
+      excerpt: `${nm[0].trim()} — namespace re-export forbidden in src/integrity/index.ts (bypasses RULE-6 name inspection)`,
+    });
+  }
+
+  // (b) Named re-exports must carry @experimental adjacent to the block when
+  //     any exported binding name matches /canonicaliz/i.
   let m: RegExpExecArray | null;
   RULE_6_EXPORT_BLOCK_PATTERN.lastIndex = 0;
   while ((m = RULE_6_EXPORT_BLOCK_PATTERN.exec(content)) !== null) {
@@ -271,7 +316,7 @@ export function checkRule6(path: string, content: string, allowed: AllowlistChec
       rule: 'RULE-6',
       path,
       line: lineNumber(content, m.index),
-      excerpt: `export { ${flagged.join(', ')} } missing @experimental in preceding comment block`,
+      excerpt: `export { ${flagged.join(', ')} } missing @experimental in directly preceding comment block`,
     });
   }
   return out;

--- a/scripts/check-class-policy-boundary.ts
+++ b/scripts/check-class-policy-boundary.ts
@@ -118,7 +118,11 @@ const RULE_5_PATTERN = /(?:from|require\()\s*['"]canonicalize['"]/g;
 // canonicalization-helper exports, not arbitrary hash-named symbols (which
 // are stable utilities under v8.5.x semver). Pattern matches the canonical
 // English-and-American spellings.
-const RULE_6_EXPORT_BLOCK_PATTERN = /^export\s+\{([^}]*)\}\s+from\s+['"][^'"]+['"]\s*;/gm;
+// Matches both `export { ... } from '...'` and the type-only re-export form
+// `export type { ... } from '...'`. The optional `type` keyword sits between
+// `export` and `{`. ASI-omitted-semicolon variants are not matched — the
+// codebase consistently terminates exports with semicolons.
+const RULE_6_EXPORT_BLOCK_PATTERN = /^export\s+(?:type\s+)?\{([^}]*)\}\s+from\s+['"][^'"]+['"]\s*;/gm;
 const RULE_6_BARRED_NAME_PATTERN = /canonicaliz/i;
 // `export * from '...'` and `export * as ns from '...'` are forbidden in
 // the guarded path entirely: they bypass name-level inspection, so a

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Install local git hooks for hounfour development.
+#
+# This script writes a pre-commit hook to .git/hooks/pre-commit that runs
+# the pollution-grep guard locally before every commit. CI enforces the
+# same check via .github/workflows/pollution-check.yml, but the local hook
+# gives sub-second feedback so the maintainer doesn't push a polluted commit.
+#
+# CT-13 from cycle-005 RC1 register; CT-NFR-2 (pollution invariant).
+#
+# Usage: bash scripts/install-hooks.sh
+#
+# The hook is per-clone (lives under .git/hooks/, which is not tracked).
+# Re-run this after cloning a fresh checkout.
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$repo_root" ]]; then
+  echo "error: must be run from within a git working tree" >&2
+  exit 1
+fi
+
+hook_path="$repo_root/.git/hooks/pre-commit"
+mkdir -p "$(dirname "$hook_path")"
+
+if [[ -e "$hook_path" ]] && ! grep -q 'hounfour-pollution-grep' "$hook_path"; then
+  echo "warning: $hook_path exists and is not managed by this script."
+  echo "  Existing hook content:"
+  sed 's/^/    /' "$hook_path" | head -20
+  echo ""
+  echo "  Backing up to ${hook_path}.bak and overwriting."
+  mv "$hook_path" "${hook_path}.bak"
+fi
+
+cat > "$hook_path" <<'HOOK_EOF'
+#!/usr/bin/env bash
+# hounfour-pollution-grep — installed by scripts/install-hooks.sh.
+#
+# Reject any commit whose staged diff contains framework-internal terms.
+# The patterns use word boundaries + case-distinction so the package name
+# (lowercase scope) and innocent words containing substrings (e.g.
+# "payload", "broadcast") are not false-positives.
+
+set -euo pipefail
+
+# Capital-L framework-name is the proper-noun reference; lowercase form
+# alone is allowed (it is the npm scope on the package itself). Concepts
+# that are always proper nouns or hyphenated identifiers match case-
+# insensitively. See CLAUDE.local.md for the full term list and rationale.
+pattern='\bLoa\b|\b[Ss]pirals?\b|\b[Ss]imstim\b|\b[Ff]latline\b|\b[Bb]ridgebuilder\b|\b[Bb]utterfreezone\b|\b[Gg]rimoires?\b|\bbeads\b|\brun-mode\b|\balways-on-vps\b'
+
+# Inspect content-bearing lines only (lines starting with + or -, excluding
+# the --- / +++ file headers).
+forbidden="$(git diff --cached --no-color 2>/dev/null \
+  | grep -E '^[+-]' \
+  | grep -vE '^(---|\+\+\+)' \
+  | grep -E "$pattern" \
+  || true)"
+
+if [[ -n "$forbidden" ]]; then
+  echo "ABORT: pollution-grep found framework-internal term(s) in staged diff."
+  echo ""
+  echo "$forbidden" | head -20
+  echo ""
+  echo "If this is intentional, the path is likely supposed to be gitignored"
+  echo "(.git/info/exclude). Run 'git status' to verify — gitignored paths"
+  echo "should not appear staged. Unstage with 'git reset HEAD <file>'."
+  echo "To bypass intentionally (rare), commit with 'git commit --no-verify'"
+  echo "and document the bypass."
+  exit 1
+fi
+
+exit 0
+HOOK_EOF
+
+chmod +x "$hook_path"
+echo "OK: pre-commit hook installed at $hook_path"
+echo "    Test the hook by staging a file containing one of the terms"
+echo "    listed in CLAUDE.local.md and running 'git commit'. The hook"
+echo "    should abort with a 'pollution-grep found ...' message."

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -50,11 +50,12 @@ set -euo pipefail
 # insensitively. See CLAUDE.local.md for the full term list and rationale.
 pattern='\bLoa\b|\b[Ss]pirals?\b|\b[Ss]imstim\b|\b[Ff]latline\b|\b[Bb]ridgebuilder\b|\b[Bb]utterfreezone\b|\b[Gg]rimoires?\b|\bbeads\b|\brun-mode\b|\balways-on-vps\b'
 
-# Inspect content-bearing lines only (lines starting with + or -, excluding
-# the --- / +++ file headers).
+# Inspect ADDITIONS only (lines starting with `+`, excluding `+++` file
+# headers). Matching deletions would block legitimate cleanup commits that
+# remove a previously-introduced forbidden term.
 forbidden="$(git diff --cached --no-color 2>/dev/null \
-  | grep -E '^[+-]' \
-  | grep -vE '^(---|\+\+\+)' \
+  | grep -E '^\+' \
+  | grep -vE '^\+\+\+' \
   | grep -E "$pattern" \
   || true)"
 

--- a/src/integrity/index.ts
+++ b/src/integrity/index.ts
@@ -54,3 +54,28 @@ export {
   type ConsumerContract,
   type ContractValidationResult,
 } from './consumer-contract.js';
+
+// Canonicalization helper — CT-01 hybrid carve-out (cycle-005 / v8.6.0).
+//
+// `safeCanonicalize` is the v8.5.0 sanctioned canonicalization helper. It is
+// re-exported here so consumers that need cross-language byte-identical output
+// (NFR-3) have a single normative TypeScript reference implementation to
+// mirror. Its export surface is governed by
+// `docs/architecture/canonicalization-spec-v8.6.md`, NOT by long-term semver
+// API stability — hence the `@experimental` annotation.
+//
+// Re-exporting any OTHER canonicalization or hashing helper from this barrel
+// without an `@experimental` tag would cross the ADR-010 class-vs-policy
+// boundary. Structural lint RULE-6 (`scripts/check-class-policy-boundary.ts`)
+// enforces this.
+//
+// @experimental — surface governed by canonicalization-spec-v8.6.md, not semver.
+// @see docs/architecture/canonicalization-spec-v8.6.md
+// @see docs/adr/ADR-010-class-vs-policy-boundary.md
+// @since v8.6.0 (PR-A3.0; CT-01 hybrid)
+export {
+  safeCanonicalize,
+  SAFE_CANONICALIZE_DEFAULT_MAX_BYTES,
+  CanonicalizeKeyCollisionError,
+  type SafeCanonicalizeOptions,
+} from '../utilities/safe-canonicalize.js';

--- a/tests/integrity/canonicalize-experimental-reexport.test.ts
+++ b/tests/integrity/canonicalize-experimental-reexport.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Verifies the CT-01 hybrid carve-out: `safeCanonicalize` and its companion
+ * exports (`SAFE_CANONICALIZE_DEFAULT_MAX_BYTES`, `CanonicalizeKeyCollisionError`,
+ * `SafeCanonicalizeOptions` type) resolve from the public integrity barrel,
+ * and the runtime behavior matches the source-of-truth helper.
+ *
+ * @see src/integrity/index.ts
+ * @see docs/architecture/canonicalization-spec-v8.6.md
+ * @since v8.6.0 (PR-A3.0)
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  safeCanonicalize,
+  SAFE_CANONICALIZE_DEFAULT_MAX_BYTES,
+  CanonicalizeKeyCollisionError,
+} from '../../src/integrity/index.js';
+import { safeCanonicalize as safeCanonicalizeFromSource } from '../../src/utilities/safe-canonicalize.js';
+
+describe('integrity barrel — CT-01 hybrid re-export', () => {
+  it('exports safeCanonicalize as a callable function', () => {
+    expect(typeof safeCanonicalize).toBe('function');
+  });
+
+  it('exports SAFE_CANONICALIZE_DEFAULT_MAX_BYTES as a number constant', () => {
+    expect(typeof SAFE_CANONICALIZE_DEFAULT_MAX_BYTES).toBe('number');
+    expect(SAFE_CANONICALIZE_DEFAULT_MAX_BYTES).toBe(100_000);
+  });
+
+  it('exports CanonicalizeKeyCollisionError as a constructable class', () => {
+    expect(typeof CanonicalizeKeyCollisionError).toBe('function');
+    const err = new CanonicalizeKeyCollisionError('test', ['a', 'b']);
+    expect(err).toBeInstanceOf(CanonicalizeKeyCollisionError);
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it('barrel-exported safeCanonicalize is the same identity as the source helper', () => {
+    expect(safeCanonicalize).toBe(safeCanonicalizeFromSource);
+  });
+
+  it('barrel-exported safeCanonicalize produces deterministic canonical output', () => {
+    const a = safeCanonicalize({ b: 2, a: 1 });
+    const b = safeCanonicalize({ a: 1, b: 2 });
+    expect(a).toBe(b);
+    expect(a).toBe('{"a":1,"b":2}');
+  });
+
+  it('barrel-exported safeCanonicalize NFC-normalizes string values', () => {
+    // U+00E9 (precomposed) vs U+0065 U+0301 (decomposed) — same visible char.
+    const precomposed = safeCanonicalize({ name: 'é' });
+    const decomposed = safeCanonicalize({ name: 'é' });
+    expect(precomposed).toBe(decomposed);
+  });
+});

--- a/tests/scripts/check-class-policy-boundary.test.ts
+++ b/tests/scripts/check-class-policy-boundary.test.ts
@@ -316,4 +316,20 @@ export { safeCanonicalize } from '../utilities/safe-canonicalize.js';
     const content = `export * from './a.js';\nexport * as ns from './b.js';\n`;
     expect(checkRule6('src/utilities/index.ts', content, noAllow)).toHaveLength(0);
   });
+
+  // F-003 (iter-2) — type-only re-exports. `export type { } from` was a
+  // bypass for the original regex; a canonicalize-named type-only re-export
+  // without an annotation must still be flagged.
+  it('flags `export type { } from` re-exports of canonicalize-named types', () => {
+    const content = `export type { CanonicalizeOptions } from '../utilities/safe-canonicalize.js';\n`;
+    expect(checkRule6(RULE_6_GUARDED_PATH, content, noAllow)).toHaveLength(1);
+  });
+
+  it('accepts `export type { } from` when @experimental is adjacent', () => {
+    const content = `
+// @experimental — type-only re-export under canonicalization-spec governance.
+export type { CanonicalizeOptions } from '../utilities/safe-canonicalize.js';
+`;
+    expect(checkRule6(RULE_6_GUARDED_PATH, content, noAllow)).toHaveLength(0);
+  });
 });

--- a/tests/scripts/check-class-policy-boundary.test.ts
+++ b/tests/scripts/check-class-policy-boundary.test.ts
@@ -15,7 +15,9 @@ import {
   checkRule3SchemaFile,
   checkRule4,
   checkRule5,
+  checkRule6,
   RULE_5_ALLOWED_PATH,
+  RULE_6_GUARDED_PATH,
 } from '../../scripts/check-class-policy-boundary.ts';
 
 const noAllow = () => false;
@@ -168,5 +170,107 @@ describe("RULE-5 — direct 'canonicalize' import outside safe-canonicalize.ts (
     const allowed = (rule: string, path: string) =>
       rule === 'RULE-5' && path === 'src/utilities/signature.ts';
     expect(checkRule5('src/utilities/signature.ts', content, allowed)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RULE-6 — canonicalize/hash re-exports from src/integrity/index.ts (CT-01)
+// ---------------------------------------------------------------------------
+//
+// Added in cycle-005 / v8.6.0 (PR-A3.0) to make the CT-01 hybrid carve-out
+// explicit: re-exporting `safeCanonicalize` from @0xhoneyjar/loa-hounfour/integrity
+// is allowed under @experimental governance per
+// docs/architecture/canonicalization-spec-v8.6.md, but any other canonicalize-
+// or hash-named re-export added later must either carry @experimental in the
+// preceding comment block or be path-allowlisted.
+
+describe('RULE-6 — canonicalize/hash re-exports require @experimental annotation', () => {
+  it('does not flag a re-export that has @experimental in a // comment block', () => {
+    const content = `
+// safeCanonicalize is the v8.5.0 helper.
+//
+// @experimental — surface governed by canonicalization-spec-v8.6.md, not semver.
+export {
+  safeCanonicalize,
+} from '../utilities/safe-canonicalize.js';
+`;
+    expect(checkRule6(RULE_6_GUARDED_PATH, content, noAllow)).toHaveLength(0);
+  });
+
+  it('does not flag a re-export that has @experimental in a JSDoc block', () => {
+    const content = `
+/**
+ * Canonicalization helper.
+ * @experimental
+ */
+export { safeCanonicalize } from '../utilities/safe-canonicalize.js';
+`;
+    expect(checkRule6(RULE_6_GUARDED_PATH, content, noAllow)).toHaveLength(0);
+  });
+
+  it('flags a canonicalize re-export without an annotation', () => {
+    const content = `
+// Plain re-export — stable governance, no carve-out tag.
+export { canonicalizeForHash } from './hash-helper.js';
+`;
+    expect(checkRule6(RULE_6_GUARDED_PATH, content, noAllow)).toHaveLength(1);
+  });
+
+  it('flags a Canonicalize-prefixed re-export without an annotation', () => {
+    const content = `export { CanonicalizeHelper } from './helper.js';\n`;
+    expect(checkRule6(RULE_6_GUARDED_PATH, content, noAllow)).toHaveLength(1);
+  });
+
+  it('does not flag generic hash exports (CT-01 narrows to canonicalize only)', () => {
+    // Pre-existing v8.5.x exports like computeReqHash / EMPTY_BODY_HASH are
+    // stable utilities; RULE-6 deliberately does not police them.
+    const content = `export { computeHash, EMPTY_BODY_HASH } from './req-hash.js';\n`;
+    expect(checkRule6(RULE_6_GUARDED_PATH, content, noAllow)).toHaveLength(0);
+  });
+
+  it('does not flag re-exports of unrelated names', () => {
+    const content = `export { someOtherSymbol } from './elsewhere.js';\n`;
+    expect(checkRule6(RULE_6_GUARDED_PATH, content, noAllow)).toHaveLength(0);
+  });
+
+  it('only applies to src/integrity/index.ts (other paths ignored)', () => {
+    const content = `export { canonicalizeAnything } from './x.js';\n`;
+    expect(checkRule6('src/utilities/index.ts', content, noAllow)).toHaveLength(0);
+    expect(checkRule6('src/integrity/some-other-file.ts', content, noAllow)).toHaveLength(0);
+  });
+
+  it('handles type-prefixed and aliased exports correctly', () => {
+    const contentWithTag = `
+// @experimental tagged group export
+export {
+  safeCanonicalize,
+  type SafeCanonicalizeOptions,
+  CanonicalizeKeyCollisionError as CanonError,
+} from '../utilities/safe-canonicalize.js';
+`;
+    expect(checkRule6(RULE_6_GUARDED_PATH, contentWithTag, noAllow)).toHaveLength(0);
+
+    const contentWithoutTag = `
+export {
+  safeCanonicalize,
+  type SafeCanonicalizeOptions,
+} from '../utilities/safe-canonicalize.js';
+`;
+    expect(checkRule6(RULE_6_GUARDED_PATH, contentWithoutTag, noAllow)).toHaveLength(1);
+  });
+
+  it('respects path allowlist', () => {
+    const content = `export { canonicalizeNew } from './new.js';\n`;
+    const allowed = (rule: string, path: string) =>
+      rule === 'RULE-6' && path === RULE_6_GUARDED_PATH;
+    expect(checkRule6(RULE_6_GUARDED_PATH, content, allowed)).toHaveLength(0);
+  });
+
+  it('flags multiple non-tagged canonicalize blocks independently', () => {
+    const content = `
+export { canonicalizeOne } from './a.js';
+export { canonicalizeTwo } from './b.js';
+`;
+    expect(checkRule6(RULE_6_GUARDED_PATH, content, noAllow)).toHaveLength(2);
   });
 });

--- a/tests/scripts/check-class-policy-boundary.test.ts
+++ b/tests/scripts/check-class-policy-boundary.test.ts
@@ -273,4 +273,47 @@ export { canonicalizeTwo } from './b.js';
 `;
     expect(checkRule6(RULE_6_GUARDED_PATH, content, noAllow)).toHaveLength(2);
   });
+
+  // F-001 — adjacency hardening. A distant `@experimental` comment block
+  // separated from the export by intervening *code* (not just blank/comment
+  // lines) must NOT authorize the re-export. The annotation contract is
+  // between a comment block and the export *immediately following* it.
+  it('does NOT accept @experimental from a distant non-adjacent comment block', () => {
+    const content = `
+// @experimental — this comment authorizes nothing in particular.
+export { unrelatedSymbol } from './unrelated.js';
+
+const intervening = 1;
+
+export { canonicalizeNew } from './new.js';
+`;
+    expect(checkRule6(RULE_6_GUARDED_PATH, content, noAllow)).toHaveLength(1);
+  });
+
+  it('accepts @experimental in a comment block separated only by blank lines', () => {
+    const content = `
+// @experimental — surface governed by canonicalization-spec-v8.6.md.
+
+
+export { safeCanonicalize } from '../utilities/safe-canonicalize.js';
+`;
+    expect(checkRule6(RULE_6_GUARDED_PATH, content, noAllow)).toHaveLength(0);
+  });
+
+  // F-002 — namespace re-exports bypass per-name inspection and are
+  // forbidden in the guarded path entirely.
+  it('flags `export * from` even when no canonicalize name appears literally', () => {
+    const content = `export * from './some-module.js';\n`;
+    expect(checkRule6(RULE_6_GUARDED_PATH, content, noAllow)).toHaveLength(1);
+  });
+
+  it('flags `export * as ns from` namespace alias re-exports', () => {
+    const content = `export * as integrity from './some-module.js';\n`;
+    expect(checkRule6(RULE_6_GUARDED_PATH, content, noAllow)).toHaveLength(1);
+  });
+
+  it('does not flag namespace re-exports in non-guarded paths', () => {
+    const content = `export * from './a.js';\nexport * as ns from './b.js';\n`;
+    expect(checkRule6('src/utilities/index.ts', content, noAllow)).toHaveLength(0);
+  });
 });

--- a/tests/scripts/install-hooks.test.ts
+++ b/tests/scripts/install-hooks.test.ts
@@ -61,6 +61,11 @@ describe('install-hooks.sh — pollution pre-commit hook (CT-13)', () => {
   });
 
   it('rejects a commit whose staged diff contains a forbidden term', () => {
+    // The forbidden term is split via string concatenation so this test
+    // file's source itself does not match the pollution-grep when the
+    // hook scans commits that touch this directory. The runtime
+    // concatenation produces the literal forbidden term in the
+    // file-on-disk that the test repo commits.
     writeFileSync(join(workDir, 'polluted.txt'), 'this file mentions sp' + 'iral which is forbidden\n');
     execFileSync('git', ['add', 'polluted.txt'], { cwd: workDir });
     const result = run('git', ['commit', '-m', 'add polluted file'], workDir);
@@ -74,7 +79,8 @@ describe('install-hooks.sh — pollution pre-commit hook (CT-13)', () => {
     execFileSync('git', ['add', 'README.md'], { cwd: workDir });
     execFileSync('git', ['commit', '-m', 'initial'], { cwd: workDir });
 
-    // Now amend with a pollution term.
+    // Now amend with a pollution term — concatenated for the same
+    // reason as the previous test (avoid self-match on this source file).
     writeFileSync(join(workDir, 'README.md'), 'first version\nspi' + 'ral added\n');
     execFileSync('git', ['add', 'README.md'], { cwd: workDir });
     const result = run('git', ['commit', '-m', 'add forbidden term'], workDir);

--- a/tests/scripts/install-hooks.test.ts
+++ b/tests/scripts/install-hooks.test.ts
@@ -1,0 +1,91 @@
+/**
+ * End-to-end smoke test for scripts/install-hooks.sh.
+ *
+ * Verifies that the installed pre-commit hook intercepts a synthetic
+ * commit whose staged diff contains a forbidden framework-internal term,
+ * and accepts a clean commit. Forbidden terms are constructed at runtime
+ * via string concatenation so this source file itself stays clean of the
+ * pollution-grep pattern.
+ *
+ * @see scripts/install-hooks.sh
+ * @see CLAUDE.local.md
+ * @since v8.6.0 (PR-A3.0; CT-13)
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, copyFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const repoRoot = resolve(__dirname, '..', '..');
+const installScript = join(repoRoot, 'scripts', 'install-hooks.sh');
+
+/** Run a command in a working dir; return { status, stdout, stderr } without throwing. */
+function run(cmd: string, args: string[], cwd: string, env: Record<string, string> = {}) {
+  const result = spawnSync(cmd, args, {
+    cwd,
+    encoding: 'utf-8',
+    env: { ...process.env, ...env, GIT_AUTHOR_NAME: 'test', GIT_AUTHOR_EMAIL: 't@t', GIT_COMMITTER_NAME: 'test', GIT_COMMITTER_EMAIL: 't@t' },
+  });
+  return { status: result.status, stdout: result.stdout ?? '', stderr: result.stderr ?? '' };
+}
+
+describe('install-hooks.sh — pollution pre-commit hook (CT-13)', () => {
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), 'hounfour-hook-test-'));
+    // Initialize a fresh git repo
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: workDir });
+    execFileSync('git', ['config', 'user.email', 't@t'], { cwd: workDir });
+    execFileSync('git', ['config', 'user.name', 'test'], { cwd: workDir });
+    // Install the hook (script needs to find the repo root via `git rev-parse --show-toplevel`)
+    execFileSync('bash', [installScript], { cwd: workDir });
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it('installs the hook at .git/hooks/pre-commit and makes it executable', () => {
+    const hookPath = join(workDir, '.git', 'hooks', 'pre-commit');
+    const stat = run('test', ['-x', hookPath], workDir);
+    expect(stat.status).toBe(0);
+  });
+
+  it('accepts a commit whose staged diff is clean of pollution terms', () => {
+    writeFileSync(join(workDir, 'clean.txt'), 'this is a clean file with no forbidden terms\n');
+    execFileSync('git', ['add', 'clean.txt'], { cwd: workDir });
+    const result = run('git', ['commit', '-m', 'add clean file'], workDir);
+    expect(result.status).toBe(0);
+  });
+
+  it('rejects a commit whose staged diff contains a forbidden term', () => {
+    writeFileSync(join(workDir, 'polluted.txt'), 'this file mentions sp' + 'iral which is forbidden\n');
+    execFileSync('git', ['add', 'polluted.txt'], { cwd: workDir });
+    const result = run('git', ['commit', '-m', 'add polluted file'], workDir);
+    expect(result.status).not.toBe(0);
+    expect(result.stdout + result.stderr).toMatch(/ABORT.*pollution-grep/);
+  });
+
+  it('rejects a commit that adds a forbidden term to an existing file', () => {
+    // Seed a clean commit first.
+    writeFileSync(join(workDir, 'README.md'), 'first version\n');
+    execFileSync('git', ['add', 'README.md'], { cwd: workDir });
+    execFileSync('git', ['commit', '-m', 'initial'], { cwd: workDir });
+
+    // Now amend with a pollution term.
+    writeFileSync(join(workDir, 'README.md'), 'first version\nspi' + 'ral added\n');
+    execFileSync('git', ['add', 'README.md'], { cwd: workDir });
+    const result = run('git', ['commit', '-m', 'add forbidden term'], workDir);
+    expect(result.status).not.toBe(0);
+    expect(result.stdout + result.stderr).toContain('ABORT');
+  });
+
+  it('allows --no-verify bypass (documented escape hatch)', () => {
+    writeFileSync(join(workDir, 'urgent.txt'), 'sp' + 'iral mention\n');
+    execFileSync('git', ['add', 'urgent.txt'], { cwd: workDir });
+    const result = run('git', ['commit', '-m', 'urgent', '--no-verify'], workDir);
+    expect(result.status).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Opens **cycle-005** (v8.6.0) as a hygiene-only PR with no contract-shape changes. Eight committed-surface deliverables landing the spec scaffolds, hybrid carve-out enforcement, and the pollution-grep automation that the rest of cycle-005 depends on.

| Deliverable | File | Status |
|---|---|---|
| Canonicalization spec scaffold | `docs/architecture/canonicalization-spec-v8.6.md` | NEW (124 lines) |
| `safeCanonicalize` re-export under `@experimental` | `src/integrity/index.ts` | +25 lines |
| RULE-6 (canonicalize-helper carve-out) | `scripts/check-class-policy-boundary.ts` | +87 lines |
| Pre-commit hook installer | `scripts/install-hooks.sh` | NEW (81 lines) |
| CI pollution-check workflow | `.github/workflows/pollution-check.yml` | NEW (66 lines) |
| RULE-6 + helper test coverage | `tests/scripts/check-class-policy-boundary.test.ts` | +104 lines |
| Re-export annotation test | `tests/integrity/canonicalize-experimental-reexport.test.ts` | NEW (53 lines) |
| Hook installer smoke test | `tests/scripts/install-hooks.test.ts` | NEW (91 lines) |

The CT-01 hybrid carve-out lets consumers needing cross-language byte-identical canonical output mirror a single normative TypeScript reference. RULE-6 confines the carve-out: any future `canonicaliz*` re-export from `src/integrity/index.ts` must either carry `@experimental` or be explicitly path-allowlisted (which is a reviewer-attention signal). CT-13 (pollution-grep) gets both layers: sub-second local feedback via the pre-commit hook plus a binding CI gate.

## Verification

- [x] `npm run check:all` exit 0
- [x] `npm run semver:check` exit 0 (no version bump in PR-A3.0)
- [x] `npx vitest run` — **7,786 / 7,786 pass** (+21 from 7,765 baseline)
- [x] Pollution-grep clean across all 8 committed-surface files
- [x] `check-class-policy-boundary` allowlist unchanged — `safeCanonicalize` re-export passes RULE-6 by content

## Test plan

- [ ] CI green (typecheck + build + test + schema-check + semver:check + class-policy-boundary + constraints + schemas:validate)
- [ ] CI `pollution-check.yml` workflow runs on this PR and passes (validates the workflow from the workflow's own perspective)
- [ ] After merge, run `bash scripts/install-hooks.sh` to install the local pollution hook
- [ ] After merge, post the coord amendment artifacts to Issue #85 (rename + GitHub Packages distribution per CT-05); 7-business-day SLA window opens on post

## Refs

- Sprint plan: `grimoires/loa/sprint.md` §1 PR-A3.0
- CT-01 hybrid (canonicalization carve-out) from cycle-005 RC1 register
- CT-13 (pollution-grep automation) from cycle-005 RC1 register
- ADR-010 — class-vs-policy boundary