### PR TITLE
feat(cycle-005): PR-A3.2 — FR-A4 ORD-3 fail-closed opt-in + FR-A3 ORD-5 surfacing

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -174,9 +174,9 @@ type. Runtime-wise this is strict-additive — pre-v8.6.0 consumers who
 ignore the field continue to work — but TypeScript consumers using
 exhaustive-switch patterns (e.g. `assertNever(reason)` in the default
 branch of a `switch (reason)`) will fail compilation on upgrade until
-they add a case for `'chain_context_provided'`. This is the same
-classification AWS uses for "minor for runtime, major for type-strict
-consumers." Add a default branch or an explicit `'chain_context_provided'`
+they add a case for `'chain_context_provided'`. This is the standard
+"runtime-additive, type-strict-breaking" pattern for discriminated-union
+extensions. Add a default branch or an explicit `'chain_context_provided'`
 case before bumping the dependency. The same caveat applies to any
 future additions to this union; consumers preferring stricter
 compile-time guarantees may pin the type via
@@ -248,6 +248,18 @@ the maintainer ahead of the PR-A3.10 review.
    the maintainer so the soak telemetry can drive the promotion
    decision. Fire rate <1% → promote to error in PR-A3.10; 1–5% → defer
    to v8.7.0; >5% → expand the canonical vocabulary first.
+
+**Authoritative telemetry surface.** ORD-5 fires from two surfaces in
+v8.6.0: the `npm run check:constraints` static lint (developer-time
+signal, surfaces the rule definition + per-fixture violations) and the
+`validate()` runtime manifest (per-record signal, surfaces a
+`reason: 'vocabulary_drift'` entry per non-canonical key on each
+validation pass). The two surfaces are non-overlapping in practice —
+the lint runs at build time on committed fixtures; the manifest fires
+at runtime on consumer payloads — but for soak-telemetry aggregation
+driving the PR-A3.10 promotion decision, **the runtime manifest is
+authoritative**. The static lint is a developer-time ergonomic; do
+not aggregate fire counts from its output.
 
 **Telemetry exclusion: fail-closed records.** When `validate(...,
 { failClosed: true })` returns `{ valid: false, errors: [CHAIN_CONTEXT_DEFERRED:...] }`,

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -82,12 +82,147 @@ the same bar.
 
 ---
 
-## v8.5.x → v8.6.0 (Minor — pre-release: FR-A5 ed25519 pattern narrowing)
+## v8.5.x → v8.6.0 (Minor — pre-release: FR-A5 + FR-A4 + FR-A3)
 
-> **Status:** in-flight on `cycle-005`. The first landed change is FR-A5
-> (this section). Other v8.6.0 work — opt-in fail-closed (FR-A4), ORD-5
-> escalation prep (FR-A3), Tier-1/Tier-2 envelopes, builtins — lands in
+> **Status:** in-flight on `cycle-005`. Landed changes documented below
+> as they ship: FR-A5 (ed25519 pattern narrowing), FR-A4 (ORD-3 fail-
+> closed opt-in via `validate({ failClosed: true })`), FR-A3 (ORD-5
+> vocabulary-drift surfacing at validate() time). Remaining v8.6.0
+> work — Tier-1/Tier-2 envelopes, builtins, plan-governance — lands in
 > later PRs and is documented as it ships.
+
+### FR-A4 — `validate()` `failClosed` opt-in for `x-chain-bearing` schemas
+
+**Default behavior (NFR-1 — preserved unchanged from v8.5.x).** Calling
+`validate(schema, payload)` on an `x-chain-bearing` schema (currently
+only `OrgRepresentativeDelegation`) without supplying `chainContext`
+continues to return `{ valid: true, unverified_obligations: { ... } }`
+with the ORD-3 entry carrying `reason: 'context_absent'`. With chain
+context supplied, the entry carries `reason: 'pattern_matching'`. No
+v8.5.x consumer code path changes shape.
+
+**FR-A4 opt-in (additive, off-by-default).** v8.6.0 adds a new
+`failClosed?: boolean` option to `validate()`. When set to `true`, the
+chain-bearing schema validates fail-closed:
+
+```typescript
+import { validate } from '@0xhoneyjar/loa-hounfour';
+import { OrgRepresentativeDelegationSchema } from '@0xhoneyjar/loa-hounfour/governance';
+
+// Chain context absent → HARD reject (instead of v8.5.x's manifest-only)
+const result = validate(OrgRepresentativeDelegationSchema, payload, {
+  failClosed: true,
+});
+// {
+//   valid: false,
+//   errors: ['CHAIN_CONTEXT_DEFERRED: Chain-bearing schema validated with { failClosed: true } but `chainContext.granted_by_chain_records` was not supplied. ...'],
+// }
+
+// Chain context supplied → manifest entry with new reason
+const ok = validate(OrgRepresentativeDelegationSchema, payload, {
+  failClosed: true,
+  chainContext: { granted_by_chain_records: [/* full chain + sentinel */] },
+});
+// {
+//   valid: true,
+//   unverified_obligations: {
+//     unverified_rules: [{ rule_id: 'ORD-3', reason: 'chain_context_provided', ... }],
+//     ...
+//   },
+// }
+```
+
+The `'chain_context_provided'` reason is the explicit acknowledgment that
+the consumer has assembled the chain and accepts the v9.0.0 fail-closed
+default semantics ahead of the flip.
+
+**Manifest reason matrix (per validate-call mode):**
+
+| Mode | Chain context | Result | ORD-3 manifest reason |
+|---|---|---|---|
+| Default (`failClosed` unset / `false`) | absent or malformed | `valid: true` | `context_absent` |
+| Default | present | `valid: true` | `pattern_matching` |
+| Opt-in (`failClosed: true`) | absent or malformed | `valid: false`, error: `CHAIN_CONTEXT_DEFERRED:` | (no manifest — error is the audit signal) |
+| Opt-in | present | `valid: true` | `chain_context_provided` |
+
+Twelve cross-product fixtures under
+`vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/` exercise every
+cell of the matrix × {genesis-rooted, chained} record kinds.
+
+**Consumer migration path.**
+
+1. **Today (v8.6.0):** continue calling `validate(schema, payload)` with
+   no options — behavior is identical to v8.5.x. No work required.
+2. **Pre-v9.0.0 hardening (recommended):** opt in to fail-closed
+   semantics in production code paths where chain assembly is feasible.
+   Pass `{ failClosed: true, chainContext: { granted_by_chain_records: [...] } }`
+   to receive the `chain_context_provided` acknowledgment manifest entry.
+   Audits can attribute v9.0.0 readiness state per-record from the
+   manifest reason.
+3. **v9.0.0 (forward-pointer):** `failClosed: true` becomes the default.
+   Code paths still calling `validate(schema, payload)` without chain
+   context will start receiving `{ valid: false, errors: ['CHAIN_CONTEXT_DEFERRED: ...'] }`.
+   Consumers MUST either supply chain context or explicitly opt out via
+   `{ failClosed: false }` (which the v9.0.0 release notes will frame as
+   a v9.0.x-only escape hatch removed in v10.0.0). The `'context_absent'`
+   reason will be retired in v9.0.0; the `'pattern_matching'` reason
+   stays for non-fail-closed code paths.
+
+**The `x-chain-bearing` schema flag.** v8.6.0 adds
+`'x-chain-bearing': true` to `OrgRepresentativeDelegationSchema`'s
+TypeBox options, mirroring the existing `'x-crypto-bearing'` /
+`'x-integrity-bearing'` flags. The validator routes the failClosed
+opt-in path on this flag; future schemas opting into the same
+fail-closed contract simply add the flag and inherit the routing.
+
+### FR-A3 — ORD-5 vocabulary-drift surfacing at `validate()` time
+
+**v8.5.x behavior.** ORD-5 (`capability_scope` keys MUST be in the
+canonical CapabilityScope vocabulary: `billing | governance | inference
+| delegation | audit | composition`) is defined in
+`constraints/OrgRepresentativeDelegation.constraints.json` with
+`severity: 'warning'` and `evaluator: 'library'`, but only the
+`npm run check:constraints` static lint surfaced it. Calling
+`validate()` returned no manifest entry for non-canonical keys — the
+authorization-drift signal lived only in the lint output.
+
+**v8.6.0 change (additive only).** `validate()` now surfaces ORD-5 as a
+manifest entry at runtime. For each `capability_scope` key outside the
+canonical set, one entry is emitted:
+
+```typescript
+{
+  rule_id: 'ORD-5',
+  evaluator: 'library',
+  reason: 'vocabulary_drift',
+  evaluation_note: 'capability_scope key "<key>" is outside the canonical vocabulary. ...',
+  consumer_acknowledgment_required: true,
+  ...
+}
+```
+
+The `valid: true | false` outcome **does not change** — ORD-5 stays at
+`severity: 'warning'` for v8.6.0 per the cycle-005 soak window. Promotion
+to `severity: 'error'` (which would flip ORD-5 onto the `valid: false`
+path) is a PR-A3.10 decision driven by soak telemetry — consumers are
+asked to aggregate `reason: 'vocabulary_drift'` entry counts per
+calendar window across their record corpus and surface the fire rate to
+the maintainer ahead of the PR-A3.10 review.
+
+**Consumer migration path.**
+
+1. **Today (v8.6.0):** existing fixtures using canonical keys
+   (`governance`, `billing`, etc.) emit no ORD-5 entries — no test
+   changes required.
+2. **Drift detection:** add a manifest-walk step in your conformance
+   suite that flags `reason: 'vocabulary_drift'` entries and surfaces
+   the per-key fire counts. The aggregation period (daily, weekly) and
+   the surfacing channel (dashboard, log line, alert) is consumer-
+   chosen — hounfour does not specify either.
+3. **Pre-PR-A3.10 (mid-cycle-005):** report aggregate fire rates back to
+   the maintainer so the soak telemetry can drive the promotion
+   decision. Fire rate <1% → promote to error in PR-A3.10; 1–5% → defer
+   to v8.7.0; >5% → expand the canonical vocabulary first.
 
 ### FR-A5 — Signature pattern narrowing on three v8.4.0 schemas
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -168,6 +168,31 @@ cell of the matrix × {genesis-rooted, chained} record kinds.
    reason will be retired in v9.0.0; the `'pattern_matching'` reason
    stays for non-fail-closed code paths.
 
+**Type-surface compatibility (TypeScript consumers).** v8.6.0 adds
+`'chain_context_provided'` to the `UnverifiedObligationReason` union
+type. Runtime-wise this is strict-additive — pre-v8.6.0 consumers who
+ignore the field continue to work — but TypeScript consumers using
+exhaustive-switch patterns (e.g. `assertNever(reason)` in the default
+branch of a `switch (reason)`) will fail compilation on upgrade until
+they add a case for `'chain_context_provided'`. This is the same
+classification AWS uses for "minor for runtime, major for type-strict
+consumers." Add a default branch or an explicit `'chain_context_provided'`
+case before bumping the dependency. The same caveat applies to any
+future additions to this union; consumers preferring stricter
+compile-time guarantees may pin the type via
+`Extract<UnverifiedObligationReason, 'context_absent' | 'pattern_matching' | ...>`
+to opt out of additivity at the type level.
+
+**Stable error-prefix matching contract.** The `CHAIN_CONTEXT_DEFERRED:`
+prefix on the `errors[0]` string is a **stable matching contract**
+through v9.0.0. Consumers programmatically distinguishing this error
+from generic TypeBox structural errors (which share the same `string[]`
+channel) MAY rely on `errors.some(e => e.startsWith('CHAIN_CONTEXT_DEFERRED:'))`.
+A structured error variant (e.g. an enumerated error-code field) is a
+candidate for v9.0.0 alongside the default-flip — track the upgrade in
+the v9.0.0 release notes if it lands. Until then, the prefix is the
+contract.
+
 **The `x-chain-bearing` schema flag.** v8.6.0 adds
 `'x-chain-bearing': true` to `OrgRepresentativeDelegationSchema`'s
 TypeBox options, mirroring the existing `'x-crypto-bearing'` /
@@ -223,6 +248,19 @@ the maintainer ahead of the PR-A3.10 review.
    the maintainer so the soak telemetry can drive the promotion
    decision. Fire rate <1% → promote to error in PR-A3.10; 1–5% → defer
    to v8.7.0; >5% → expand the canonical vocabulary first.
+
+**Telemetry exclusion: fail-closed records.** When `validate(...,
+{ failClosed: true })` returns `{ valid: false, errors: [CHAIN_CONTEXT_DEFERRED:...] }`,
+the early-return path bypasses ORD-5 surfacing — the record is rejected
+outright and no manifest is emitted. Consumers aggregating
+`reason: 'vocabulary_drift'` fire counts MUST exclude fail-closed
+rejections from the denominator for fire-rate calculation; the fire
+rate is conventionally defined over **records that produced a manifest**
+(i.e. `valid: true` results), not over the total call count. This
+matters for the PR-A3.10 promotion-decision thresholds — a high
+fail-closed rejection rate combined with a moderate vocabulary-drift
+rate could otherwise misrepresent the soak telemetry. Document the
+denominator choice in your aggregation pipeline.
 
 ### FR-A5 — Signature pattern narrowing on three v8.4.0 schemas
 

--- a/schemas/index.json
+++ b/schemas/index.json
@@ -2,7 +2,7 @@
   "$schema": "https://schemas.0xhoneyjar.com/loa-hounfour/index",
   "version": "8.5.2",
   "min_supported_version": "6.0.0",
-  "generated_at": "2026-05-08T10:16:10.005Z",
+  "generated_at": "2026-05-08T11:19:25.813Z",
   "schemas": [
     {
       "name": "jwt-claims",
@@ -1256,7 +1256,7 @@
       "name": "org-representative-delegation",
       "$id": "https://schemas.0xhoneyjar.com/loa-hounfour/8.5.2/org-representative-delegation",
       "file": "org-representative-delegation.schema.json",
-      "description": "Append-only delegation record binding org → representative, signed under a signing_context envelope. Cross-field rules in constraints/OrgRepresentativeDelegation.constraints.json (ORD-1..3)."
+      "description": "Append-only delegation record binding org → representative, signed under a signing_context envelope. Cross-field rules in constraints/OrgRepresentativeDelegation.constraints.json (ORD-1..3). Carries `x-chain-bearing: true` (FR-A4): consumers MAY pass `{ failClosed: true }` to validate() to reject records when `chainContext.granted_by_chain_records` is absent — see MIGRATION.md v8.5.x → v8.6.0 FR-A4 section for the opt-in contract."
     },
     {
       "name": "succession-policy",

--- a/schemas/index.json
+++ b/schemas/index.json
@@ -2,7 +2,7 @@
   "$schema": "https://schemas.0xhoneyjar.com/loa-hounfour/index",
   "version": "8.5.2",
   "min_supported_version": "6.0.0",
-  "generated_at": "2026-05-08T11:19:25.813Z",
+  "generated_at": "2026-05-08T11:39:03.346Z",
   "schemas": [
     {
       "name": "jwt-claims",
@@ -1256,7 +1256,7 @@
       "name": "org-representative-delegation",
       "$id": "https://schemas.0xhoneyjar.com/loa-hounfour/8.5.2/org-representative-delegation",
       "file": "org-representative-delegation.schema.json",
-      "description": "Append-only delegation record binding org → representative, signed under a signing_context envelope. Cross-field rules in constraints/OrgRepresentativeDelegation.constraints.json (ORD-1..3). Carries `x-chain-bearing: true` (FR-A4): consumers MAY pass `{ failClosed: true }` to validate() to reject records when `chainContext.granted_by_chain_records` is absent — see MIGRATION.md v8.5.x → v8.6.0 FR-A4 section for the opt-in contract."
+      "description": "Append-only delegation record binding org → representative, signed under a signing_context envelope. Cross-field rules in constraints/OrgRepresentativeDelegation.constraints.json (ORD-1..3). Carries `x-chain-bearing: true` — see TypeScript JSDoc on the export and MIGRATION.md v8.5.x → v8.6.0 §FR-A4 for the failClosed opt-in contract."
     },
     {
       "name": "succession-policy",

--- a/schemas/org-representative-delegation.schema.json
+++ b/schemas/org-representative-delegation.schema.json
@@ -3,7 +3,8 @@
   "$id": "https://schemas.0xhoneyjar.com/loa-hounfour/8.5.2/org-representative-delegation",
   "additionalProperties": false,
   "x-cross-field-validated": true,
-  "description": "Append-only delegation record binding org → representative, signed under a signing_context envelope. Cross-field rules in constraints/OrgRepresentativeDelegation.constraints.json (ORD-1..3).",
+  "x-chain-bearing": true,
+  "description": "Append-only delegation record binding org → representative, signed under a signing_context envelope. Cross-field rules in constraints/OrgRepresentativeDelegation.constraints.json (ORD-1..3). Carries `x-chain-bearing: true` (FR-A4): consumers MAY pass `{ failClosed: true }` to validate() to reject records when `chainContext.granted_by_chain_records` is absent — see MIGRATION.md v8.5.x → v8.6.0 FR-A4 section for the opt-in contract.",
   "type": "object",
   "required": [
     "delegation_id",

--- a/schemas/org-representative-delegation.schema.json
+++ b/schemas/org-representative-delegation.schema.json
@@ -4,7 +4,7 @@
   "additionalProperties": false,
   "x-cross-field-validated": true,
   "x-chain-bearing": true,
-  "description": "Append-only delegation record binding org → representative, signed under a signing_context envelope. Cross-field rules in constraints/OrgRepresentativeDelegation.constraints.json (ORD-1..3). Carries `x-chain-bearing: true` (FR-A4): consumers MAY pass `{ failClosed: true }` to validate() to reject records when `chainContext.granted_by_chain_records` is absent — see MIGRATION.md v8.5.x → v8.6.0 FR-A4 section for the opt-in contract.",
+  "description": "Append-only delegation record binding org → representative, signed under a signing_context envelope. Cross-field rules in constraints/OrgRepresentativeDelegation.constraints.json (ORD-1..3). Carries `x-chain-bearing: true` — see TypeScript JSDoc on the export and MIGRATION.md v8.5.x → v8.6.0 §FR-A4 for the failClosed opt-in contract.",
   "type": "object",
   "required": [
     "delegation_id",

--- a/src/constraints/unverified-obligations.ts
+++ b/src/constraints/unverified-obligations.ts
@@ -41,6 +41,7 @@ import type { Constraint, ConstraintFile } from './types.js';
  * `INTEGRITY_DEFERRED` paths) populate the new values.
  */
 export type UnverifiedObligationReason =
+  | 'chain_context_provided'
   | 'context_absent'
   | 'crypto_deferred'
   | 'integrity_deferred'
@@ -72,7 +73,11 @@ export interface UnverifiedObligationEntry {
    * `pattern_matching` — pattern-matched obligation (reserved for future
    * pattern-DSL rules).
    * `vocabulary_drift` — value lies outside a canonical vocabulary
-   * (currently only ORD-5 capability_scope).
+   * (currently ORD-5 capability_scope; surfaced at validate() time in
+   * v8.6.0 per FR-A3).
+   * `chain_context_provided` — FR-A4 (v8.6.0) opt-in acknowledgment that
+   * the consumer supplied `chainContext.granted_by_chain_records` and
+   * accepts the v9.0.0 fail-closed semantics ahead of the default flip.
    */
   reason?: UnverifiedObligationReason;
   /** Human explanation of the consumer obligation. */

--- a/src/governance/org-representative-delegation.ts
+++ b/src/governance/org-representative-delegation.ts
@@ -174,10 +174,9 @@ export const OrgRepresentativeDelegationSchema = Type.Object(
       'Append-only delegation record binding org → representative, signed under '
       + 'a signing_context envelope. Cross-field rules in '
       + 'constraints/OrgRepresentativeDelegation.constraints.json (ORD-1..3). '
-      + 'Carries `x-chain-bearing: true` (FR-A4): consumers MAY pass '
-      + '`{ failClosed: true }` to validate() to reject records when '
-      + '`chainContext.granted_by_chain_records` is absent — see MIGRATION.md '
-      + 'v8.5.x → v8.6.0 FR-A4 section for the opt-in contract.',
+      + 'Carries `x-chain-bearing: true` — see TypeScript JSDoc on the export '
+      + 'and MIGRATION.md v8.5.x → v8.6.0 §FR-A4 for the failClosed opt-in '
+      + 'contract.',
   },
 );
 export type OrgRepresentativeDelegation = Static<typeof OrgRepresentativeDelegationSchema>;

--- a/src/governance/org-representative-delegation.ts
+++ b/src/governance/org-representative-delegation.ts
@@ -169,10 +169,15 @@ export const OrgRepresentativeDelegationSchema = Type.Object(
     $id: 'OrgRepresentativeDelegation',
     additionalProperties: false,
     'x-cross-field-validated': true,
+    'x-chain-bearing': true,
     description:
       'Append-only delegation record binding org → representative, signed under '
       + 'a signing_context envelope. Cross-field rules in '
-      + 'constraints/OrgRepresentativeDelegation.constraints.json (ORD-1..3).',
+      + 'constraints/OrgRepresentativeDelegation.constraints.json (ORD-1..3). '
+      + 'Carries `x-chain-bearing: true` (FR-A4): consumers MAY pass '
+      + '`{ failClosed: true }` to validate() to reject records when '
+      + '`chainContext.granted_by_chain_records` is absent — see MIGRATION.md '
+      + 'v8.5.x → v8.6.0 FR-A4 section for the opt-in contract.',
   },
 );
 export type OrgRepresentativeDelegation = Static<typeof OrgRepresentativeDelegationSchema>;

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -1343,13 +1343,14 @@ export function validate<T extends TSchema>(
         errors: [
           'CHAIN_CONTEXT_DEFERRED: Chain-bearing schema validated with ' +
             '{ failClosed: true } but `chainContext.granted_by_chain_records` ' +
-            'was not supplied. ORD-3 cannot be library-evaluated against a ' +
-            'single record in isolation; assemble the chain (the record under ' +
-            'validation plus all ancestors back to the genesis-rooted record, ' +
-            'plus the synthetic terminator `{ delegation_id: "genesis:org-public-key" }`) ' +
-            'and pass it as `{ chainContext: { granted_by_chain_records: [...] } }`. ' +
-            'See MIGRATION.md v8.5.x → v8.6.0 FR-A4 section for the opt-in contract ' +
-            'and the v9.0.0 default-flip forward-pointer.',
+            'was absent or not a non-empty array. ORD-3 cannot be library-' +
+            'evaluated against a single record in isolation; assemble the ' +
+            'chain (the record under validation plus all ancestors back to ' +
+            'the genesis-rooted record, plus the synthetic terminator ' +
+            '`{ delegation_id: "genesis:org-public-key" }`) and pass it as ' +
+            '`{ chainContext: { granted_by_chain_records: [...] } }`. ' +
+            'See MIGRATION.md v8.5.x → v8.6.0 FR-A4 section for the opt-in ' +
+            'contract and the v9.0.0 default-flip forward-pointer.',
         ],
       };
     }
@@ -1399,6 +1400,16 @@ export function validate<T extends TSchema>(
   // Severity stays 'warning' for v8.6.0 — no behavioral change to the
   // valid/invalid outcome (`valid: true` continues to hold). Promotion
   // to `severity: 'error'` is a PR-A3.10 decision per soak telemetry.
+  //
+  // TODO(cycle-005, deferred): The dispatch is currently $id-keyed because
+  // `OrgRepresentativeDelegation` is the only vocabulary-bearing schema
+  // in cycle-005. When a second vocabulary check lands (e.g., a future
+  // capability-scope-bearing schema or a different controlled-vocabulary
+  // field), generalize this block to a metadata-driven `'x-vocabulary-bearing'`
+  // flag with a descriptor `{ field: '<name>', canonical_set: <Set<string>> }`,
+  // mirroring the `'x-chain-bearing'` generalization that FR-A4 introduced.
+  // Single-schema today, partial-generalization deferred to avoid
+  // over-engineering the metadata surface ahead of a second concrete user.
   if (
     schema.$id === 'OrgRepresentativeDelegation' &&
     typeof data === 'object' &&
@@ -1408,9 +1419,13 @@ export function validate<T extends TSchema>(
     const capabilityScope = (data as Record<string, unknown>).capability_scope;
     if (typeof capabilityScope === 'object' && capabilityScope !== null) {
       const canonical = new Set<string>(CAPABILITY_SCOPES);
-      const driftKeys = Object.keys(capabilityScope).filter(
-        (k) => !canonical.has(k),
-      );
+      // F2 mitigation (PR-A3.2 iter-1): sort drift keys before iteration so
+      // manifest entry order is deterministic across input JSON serialization
+      // variations — content-addressable diffing across corpora does not
+      // depend on upstream key-order accidents.
+      const driftKeys = Object.keys(capabilityScope)
+        .filter((k) => !canonical.has(k))
+        .sort();
       for (const driftKey of driftKeys) {
         obligations.push({
           rule_id: 'ORD-5',

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -1408,13 +1408,18 @@ export function validate<T extends TSchema>(
   //
   // TODO(cycle-005, deferred): The dispatch is currently $id-keyed because
   // `OrgRepresentativeDelegation` is the only vocabulary-bearing schema
-  // in cycle-005. When a second vocabulary check lands (e.g., a future
-  // capability-scope-bearing schema or a different controlled-vocabulary
-  // field), generalize this block to a metadata-driven `'x-vocabulary-bearing'`
-  // flag with a descriptor `{ field: '<name>', canonical_set: <Set<string>> }`,
-  // mirroring the `'x-chain-bearing'` generalization that FR-A4 introduced.
-  // Single-schema today, partial-generalization deferred to avoid
-  // over-engineering the metadata surface ahead of a second concrete user.
+  // in cycle-005. **Generalization trigger:** when a second
+  // controlled-vocabulary field lands on any schema in cycle-005 or
+  // later (e.g., a `Resource.tag_scope` field with a canonical tag set,
+  // or a second capability-scope-bearing record), generalize this block
+  // to a metadata-driven `'x-vocabulary-bearing'` flag whose value is a
+  // descriptor `{ field: '<name>', canonical_set: ReadonlySet<string> }`.
+  // The generalization must mirror the `'x-chain-bearing'` schema-flag
+  // pattern that FR-A4 introduced and must be paired with a corresponding
+  // `'x-vocabulary-bearing'` schema-metadata declaration in TypeBox
+  // options on the originating schema. Single-schema today,
+  // partial-generalization deferred to avoid over-engineering the
+  // metadata surface ahead of a second concrete user.
   if (
     schema.$id === 'OrgRepresentativeDelegation' &&
     typeof data === 'object' &&
@@ -1422,7 +1427,16 @@ export function validate<T extends TSchema>(
     'capability_scope' in data
   ) {
     const capabilityScope = (data as Record<string, unknown>).capability_scope;
-    if (typeof capabilityScope === 'object' && capabilityScope !== null) {
+    // F003 mitigation (PR-A3.2 iter-3): defense-in-depth — `typeof === 'object'`
+    // returns true for arrays in JavaScript, and while the TypeBox structural
+    // check upstream rejects arrays here, an explicit `!Array.isArray()` guard
+    // costs one expression and prevents nonsense vocabulary_drift entries if
+    // validation order ever shifts in a future refactor.
+    if (
+      typeof capabilityScope === 'object' &&
+      capabilityScope !== null &&
+      !Array.isArray(capabilityScope)
+    ) {
       // F2 mitigation (PR-A3.2 iter-1): sort drift keys before iteration so
       // manifest entry order is deterministic across input JSON serialization
       // variations — content-addressable diffing across corpora does not

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -30,6 +30,11 @@ import { InvokeResponseSchema, UsageReportSchema } from '../schemas/invoke-respo
 import { StreamEventSchema } from '../schemas/stream-events.js';
 import { RoutingPolicySchema } from '../schemas/routing-policy.js';
 import { CAPABILITY_SCOPES } from '../schemas/agent-identity.js';
+
+// Canonical CapabilityScope set, hoisted to module scope so per-validate-call
+// allocation cost is amortized across calls. (PR-A3.2 iter-2 F-002 mitigation.)
+// Read-only at runtime; populated once at module load.
+const CANONICAL_CAPABILITY_SCOPES: ReadonlySet<string> = new Set(CAPABILITY_SCOPES);
 import { AgentDescriptorSchema } from '../schemas/agent-descriptor.js';
 import { BillingEntrySchema, CreditNoteSchema } from '../schemas/billing-entry.js';
 import { ConversationSchema, MessageSchema, ConversationSealingPolicySchema, AccessPolicySchema } from '../schemas/conversation.js';
@@ -1418,13 +1423,12 @@ export function validate<T extends TSchema>(
   ) {
     const capabilityScope = (data as Record<string, unknown>).capability_scope;
     if (typeof capabilityScope === 'object' && capabilityScope !== null) {
-      const canonical = new Set<string>(CAPABILITY_SCOPES);
       // F2 mitigation (PR-A3.2 iter-1): sort drift keys before iteration so
       // manifest entry order is deterministic across input JSON serialization
       // variations — content-addressable diffing across corpora does not
       // depend on upstream key-order accidents.
       const driftKeys = Object.keys(capabilityScope)
-        .filter((k) => !canonical.has(k))
+        .filter((k) => !CANONICAL_CAPABILITY_SCOPES.has(k))
         .sort();
       for (const driftKey of driftKeys) {
         obligations.push({

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -29,6 +29,7 @@ import { JwtClaimsSchema, S2SJwtClaimsSchema } from '../schemas/jwt-claims.js';
 import { InvokeResponseSchema, UsageReportSchema } from '../schemas/invoke-response.js';
 import { StreamEventSchema } from '../schemas/stream-events.js';
 import { RoutingPolicySchema } from '../schemas/routing-policy.js';
+import { CAPABILITY_SCOPES } from '../schemas/agent-identity.js';
 import { AgentDescriptorSchema } from '../schemas/agent-descriptor.js';
 import { BillingEntrySchema, CreditNoteSchema } from '../schemas/billing-entry.js';
 import { ConversationSchema, MessageSchema, ConversationSealingPolicySchema, AccessPolicySchema } from '../schemas/conversation.js';
@@ -1148,6 +1149,28 @@ export function validate<T extends TSchema>(
      *   `reason: 'context_absent'`.
      */
     chainContext?: { granted_by_chain_records?: unknown };
+    /**
+     * FR-A4 (v8.6.0) opt-in fail-closed semantics for `x-chain-bearing`
+     * schemas (currently only `OrgRepresentativeDelegation`). When set
+     * to `true`:
+     *
+     *   - If `chainContext.granted_by_chain_records` is absent or empty,
+     *     validate() returns `{ valid: false, errors: ['CHAIN_CONTEXT_DEFERRED: ...'] }`
+     *     instead of emitting an `unverified_obligations` manifest.
+     *   - If the chain context is supplied, validate() emits the ORD-3
+     *     manifest entry with `reason: 'chain_context_provided'` (the
+     *     opt-in acknowledgment) instead of the default `'pattern_matching'`.
+     *
+     * When unset or `false`, validate() preserves v8.5.x behavior exactly:
+     * the manifest is emitted with `reason: 'context_absent'` (chain
+     * absent) or `reason: 'pattern_matching'` (chain present), and the
+     * outcome is `valid: true` regardless. This default is locked for the
+     * v8.6.x line; v9.0.0 flips the default to fail-closed per the
+     * MIGRATION.md FR-A4 forward-pointer.
+     *
+     * @since v8.6.0 — FR-A4 (DP-02 option C)
+     */
+    failClosed?: boolean;
   },
 ): ValidationResult {
   const compiled = getOrCompile(schema);
@@ -1299,28 +1322,119 @@ export function validate<T extends TSchema>(
   // iter-2 F4 mitigation: silence on the context-present path would let
   // consumers conflate "library validated chain" with "library skipped
   // because no context was supplied").
-  if (schema.$id === 'OrgRepresentativeDelegation') {
+  //
+  // FR-A4 (PR-A3.2, v8.6.0): generalized from `schema.$id ===
+  // 'OrgRepresentativeDelegation'` to the metadata-driven
+  // `'x-chain-bearing': true` flag, mirroring the existing
+  // `x-crypto-bearing` / `x-integrity-bearing` patterns. When `failClosed`
+  // is opted in, chain-context-absent is a HARD reject; chain-context-
+  // present uses the `chain_context_provided` reason as the opt-in
+  // acknowledgment. Default (failClosed unset/false) preserves v8.5.x
+  // semantics exactly per NFR-1.
+  const isChainBearing = schemaRecord['x-chain-bearing'] === true;
+  if (isChainBearing) {
     const contextSupplied = hasChainContextRecords(options?.chainContext);
+    if (options?.failClosed === true && !contextSupplied) {
+      // FR-A4 fail-closed branch: reject the record outright. No manifest
+      // emission — the error itself is the audit signal, and the v9.0.0
+      // forward-pointer in MIGRATION.md documents the eventual default flip.
+      return {
+        valid: false,
+        errors: [
+          'CHAIN_CONTEXT_DEFERRED: Chain-bearing schema validated with ' +
+            '{ failClosed: true } but `chainContext.granted_by_chain_records` ' +
+            'was not supplied. ORD-3 cannot be library-evaluated against a ' +
+            'single record in isolation; assemble the chain (the record under ' +
+            'validation plus all ancestors back to the genesis-rooted record, ' +
+            'plus the synthetic terminator `{ delegation_id: "genesis:org-public-key" }`) ' +
+            'and pass it as `{ chainContext: { granted_by_chain_records: [...] } }`. ' +
+            'See MIGRATION.md v8.5.x → v8.6.0 FR-A4 section for the opt-in contract ' +
+            'and the v9.0.0 default-flip forward-pointer.',
+        ],
+      };
+    }
+    const reason: UnverifiedObligationReason =
+      options?.failClosed === true
+        ? 'chain_context_provided'
+        : (contextSupplied ? 'pattern_matching' : 'context_absent');
     obligations.push({
       rule_id: 'ORD-3',
       rule:
         'Delegation chain forms a valid DAG keyed by delegation_id, terminates at the genesis sentinel, and has chain_depth <= 20.',
       evaluator: 'consumer',
-      reason: contextSupplied ? 'pattern_matching' : 'context_absent',
-      evaluation_note: contextSupplied
-        ? 'granted_by_chain_records was supplied via options.chainContext, but validate() does NOT run ' +
-          'is_valid_dag at this layer — chain-DSL evaluation runs in npm run check:constraints. The ' +
-          'consumer MUST run the chain check itself (or wait for the runtime constraint-evaluator to ' +
-          'land in a later cycle). The manifest entry remains so the obligation is auditable even on ' +
-          'the success path; consumers reconciling the entry can branch on reason: \'pattern_matching\'.'
-        : 'granted_by_chain_records was not supplied via options.chainContext at validate() time. ' +
-          'ORD-3 cannot be library-evaluated against a single record in isolation; the consumer MUST ' +
-          'assemble the chain (the record under validation plus all ancestors back to the genesis-rooted ' +
-          'record) and pass it as `{ chainContext: { granted_by_chain_records: [...] } }` to enable ' +
-          'library-side DAG validation, OR perform the chain check consumer-side. See ' +
-          'docs/architecture/org-overseer.md for the verification profile.',
+      reason,
+      evaluation_note: options?.failClosed === true
+        ? 'granted_by_chain_records was supplied via options.chainContext under ' +
+          'FR-A4 opt-in (failClosed: true). validate() does NOT run is_valid_dag ' +
+          'at this layer — chain-DSL evaluation runs in npm run check:constraints — ' +
+          'but the manifest entry records the consumer\'s explicit acknowledgment ' +
+          'of the v9.0.0 default-flip semantics. Reason: \'chain_context_provided\' ' +
+          'distinguishes this opt-in path from the default (\'pattern_matching\') ' +
+          'so audits can attribute the v9.0.0 readiness state per record.'
+        : contextSupplied
+          ? 'granted_by_chain_records was supplied via options.chainContext, but validate() does NOT run ' +
+            'is_valid_dag at this layer — chain-DSL evaluation runs in npm run check:constraints. The ' +
+            'consumer MUST run the chain check itself (or wait for the runtime constraint-evaluator to ' +
+            'land in a later cycle). The manifest entry remains so the obligation is auditable even on ' +
+            'the success path; consumers reconciling the entry can branch on reason: \'pattern_matching\'.'
+          : 'granted_by_chain_records was not supplied via options.chainContext at validate() time. ' +
+            'ORD-3 cannot be library-evaluated against a single record in isolation; the consumer MUST ' +
+            'assemble the chain (the record under validation plus all ancestors back to the genesis-rooted ' +
+            'record) and pass it as `{ chainContext: { granted_by_chain_records: [...] } }` to enable ' +
+            'library-side DAG validation, OR perform the chain check consumer-side. See ' +
+            'docs/architecture/org-overseer.md for the verification profile.',
       consumer_acknowledgment_required: true,
     });
+  }
+
+  // ORD-5 vocabulary-drift manifest promotion (PR-A3.2 — FR-A3 v8.6.0).
+  // The constraint file flags capability_scope keys outside the canonical
+  // CAPABILITY_SCOPES vocabulary (billing, governance, inference, delegation,
+  // audit, composition) as warnings; v8.5.x evaluated this rule only at
+  // `npm run check:constraints` time. v8.6.0 surfaces it at validate() so
+  // consumers can branch on `reason: 'vocabulary_drift'` without parsing
+  // the per-call warnings array. Each non-canonical key yields one
+  // manifest entry; consumers aggregate fire counts per-window for the
+  // soak metric driving the PR-A3.10 hosaka-fm review-window decision.
+  // Severity stays 'warning' for v8.6.0 — no behavioral change to the
+  // valid/invalid outcome (`valid: true` continues to hold). Promotion
+  // to `severity: 'error'` is a PR-A3.10 decision per soak telemetry.
+  if (
+    schema.$id === 'OrgRepresentativeDelegation' &&
+    typeof data === 'object' &&
+    data !== null &&
+    'capability_scope' in data
+  ) {
+    const capabilityScope = (data as Record<string, unknown>).capability_scope;
+    if (typeof capabilityScope === 'object' && capabilityScope !== null) {
+      const canonical = new Set<string>(CAPABILITY_SCOPES);
+      const driftKeys = Object.keys(capabilityScope).filter(
+        (k) => !canonical.has(k),
+      );
+      for (const driftKey of driftKeys) {
+        obligations.push({
+          rule_id: 'ORD-5',
+          rule:
+            'capability_scope MUST bind to a member of the canonical CapabilityScope set ' +
+            '(billing, governance, inference, delegation, audit, composition). Non-canonical ' +
+            'keys are surfaced as a vocabulary_drift warning during the cycle-005 soak window; ' +
+            'promotion to error severity is a PR-A3.10 decision per soak telemetry.',
+          evaluator: 'library',
+          reason: 'vocabulary_drift',
+          evaluation_note:
+            `capability_scope key "${driftKey}" is outside the canonical vocabulary. ` +
+            'Downstream Layer-2 SignerEntry.scoped_trust and Layer-3 ' +
+            'SignerCompetenceRule.required_capability_scopes evaluators will treat ' +
+            'this key as the default trust level — a potential authorization drift. ' +
+            'Coordinate with the vocabulary maintainer before relying on the key in ' +
+            'production policy. The soak telemetry windowing (consumer aggregates ' +
+            'fire counts of `reason: \'vocabulary_drift\'` entries per validation pass ' +
+            'across calendar windows) feeds the PR-A3.10 promotion decision; see ' +
+            'NOTES.md ORD-5 fire-rate tracking template.',
+          consumer_acknowledgment_required: true,
+        });
+      }
+    }
   }
 
   if (obligations.length > 0) {

--- a/tests/governance/fr-a4-fail-closed-vectors.test.ts
+++ b/tests/governance/fr-a4-fail-closed-vectors.test.ts
@@ -22,7 +22,6 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { OrgRepresentativeDelegationSchema } from '../../src/governance/org-representative-delegation.js';
 import { validate } from '../../src/validators/index.js';
-import '../../src/validators/index.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FIXTURES_ROOT = join(

--- a/tests/governance/fr-a4-fail-closed-vectors.test.ts
+++ b/tests/governance/fr-a4-fail-closed-vectors.test.ts
@@ -1,0 +1,185 @@
+/**
+ * PR-A3.2 (FR-A4) — Cross-product fixture matrix for `validate()`'s
+ * `failClosed` opt-in on `x-chain-bearing` schemas.
+ *
+ * Walks `vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/*.json` (12
+ * fixtures: 2 modes × 3 chain-context shapes × 2 record kinds) and asserts
+ * the expected `validate()` outcome per fixture.
+ *
+ * Each fixture is a self-describing case file:
+ *   {
+ *     case_id, description, validate_options, data,
+ *     expected: { valid: true,  ord3_reason: '...' }
+ *           OR { valid: false, error_prefix: 'CHAIN_CONTEXT_DEFERRED:' }
+ *   }
+ *
+ * @see MIGRATION.md v8.5.x → v8.6.0 §FR-A4 — opt-in contract documentation
+ *      and the v9.0.0 default-flip forward-pointer
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { OrgRepresentativeDelegationSchema } from '../../src/governance/org-representative-delegation.js';
+import { validate } from '../../src/validators/index.js';
+import '../../src/validators/index.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURES_ROOT = join(
+  __dirname,
+  '..',
+  '..',
+  'vectors',
+  'OrgRepresentativeDelegation',
+  'v8.6.0-fail-closed',
+);
+
+interface FailClosedCase {
+  case_id: string;
+  description: string;
+  validate_options: {
+    failClosed?: boolean;
+    chainContext?: { granted_by_chain_records?: unknown };
+    acceptDeferred?: boolean;
+    now?: string;
+  };
+  data: unknown;
+  expected:
+    | { valid: true; ord3_reason: string }
+    | { valid: false; error_prefix: string };
+}
+
+function loadCases(): FailClosedCase[] {
+  const files = readdirSync(FIXTURES_ROOT).filter((f) => f.endsWith('.json')).sort();
+  return files.map((f) => JSON.parse(readFileSync(join(FIXTURES_ROOT, f), 'utf8')) as FailClosedCase);
+}
+
+describe('FR-A4 fail-closed cross-product matrix', () => {
+  const cases = loadCases();
+
+  it('publishes exactly 12 fixtures (2 modes × 3 contexts × 2 record kinds)', () => {
+    expect(cases.length).toBe(12);
+  });
+
+  for (const c of cases) {
+    it(`${c.case_id}: ${c.description.slice(0, 80)}…`, () => {
+      const result = validate(
+        OrgRepresentativeDelegationSchema,
+        c.data,
+        c.validate_options,
+      );
+      if (c.expected.valid === true) {
+        expect(result.valid).toBe(true);
+        if (result.valid !== true) return;
+        const manifest = result.unverified_obligations;
+        expect(manifest, 'manifest must be emitted on the valid path').toBeDefined();
+        const ord3Entry = manifest!.unverified_rules.find((r) => r.rule_id === 'ORD-3');
+        expect(ord3Entry, 'ORD-3 entry must be present').toBeDefined();
+        expect(ord3Entry!.reason).toBe(c.expected.ord3_reason);
+      } else {
+        expect(result.valid).toBe(false);
+        if (result.valid !== false) return;
+        expect(result.errors.length).toBeGreaterThan(0);
+        const matched = result.errors.some((e) => e.startsWith(c.expected.error_prefix));
+        expect(matched, `expected an error starting with "${c.expected.error_prefix}"; got ${JSON.stringify(result.errors)}`).toBe(true);
+      }
+    });
+  }
+});
+
+describe('FR-A4 default-path parity (NFR-1: v8.5.x behavior unchanged)', () => {
+  it('omits failClosed flag entirely → identical manifest reason to v8.5.x default', () => {
+    const data = JSON.parse(readFileSync(
+      join(FIXTURES_ROOT, '..', 'valid', 'canonical-001-genesis-grant.json'),
+      'utf8',
+    ));
+    const result = validate(OrgRepresentativeDelegationSchema, data);
+    expect(result.valid).toBe(true);
+    if (result.valid !== true) return;
+    const ord3 = result.unverified_obligations?.unverified_rules.find((r) => r.rule_id === 'ORD-3');
+    expect(ord3?.reason).toBe('context_absent');
+  });
+
+  it('failClosed: false (explicit) is identical to absent flag', () => {
+    const data = JSON.parse(readFileSync(
+      join(FIXTURES_ROOT, '..', 'valid', 'canonical-001-genesis-grant.json'),
+      'utf8',
+    ));
+    const a = validate(OrgRepresentativeDelegationSchema, data, { failClosed: false });
+    const b = validate(OrgRepresentativeDelegationSchema, data);
+    if (a.valid !== true || b.valid !== true) {
+      expect.fail('both calls must return valid: true');
+      return;
+    }
+    const aReason = a.unverified_obligations?.unverified_rules.find((r) => r.rule_id === 'ORD-3')?.reason;
+    const bReason = b.unverified_obligations?.unverified_rules.find((r) => r.rule_id === 'ORD-3')?.reason;
+    expect(aReason).toBe(bReason);
+    expect(aReason).toBe('context_absent');
+  });
+});
+
+describe('FR-A3 ORD-5 vocabulary-drift surfacing at validate() time', () => {
+  function loadGenesis() {
+    return JSON.parse(readFileSync(
+      join(FIXTURES_ROOT, '..', 'valid', 'canonical-001-genesis-grant.json'),
+      'utf8',
+    ));
+  }
+
+  it('canonical capability_scope key emits NO ORD-5 manifest entry', () => {
+    const data = loadGenesis();
+    const result = validate(OrgRepresentativeDelegationSchema, data);
+    expect(result.valid).toBe(true);
+    if (result.valid !== true) return;
+    const ord5 = result.unverified_obligations?.unverified_rules.find((r) => r.rule_id === 'ORD-5');
+    expect(ord5).toBeUndefined();
+  });
+
+  it('non-canonical capability_scope key emits one ORD-5 manifest entry per drift key', () => {
+    const data = loadGenesis();
+    data.capability_scope = { 'governance': 'vote-and-propose', 'custom_scope': 'arbitrary' };
+    const result = validate(OrgRepresentativeDelegationSchema, data);
+    expect(result.valid).toBe(true);
+    if (result.valid !== true) return;
+    const ord5Entries = result.unverified_obligations?.unverified_rules.filter((r) => r.rule_id === 'ORD-5') ?? [];
+    expect(ord5Entries.length).toBe(1);
+    expect(ord5Entries[0].reason).toBe('vocabulary_drift');
+    expect(ord5Entries[0].evaluator).toBe('library');
+    expect(ord5Entries[0].evaluation_note).toContain('custom_scope');
+  });
+
+  it('two non-canonical capability_scope keys emit two ORD-5 manifest entries', () => {
+    const data = loadGenesis();
+    data.capability_scope = { 'foo': 'bar', 'baz': 'qux' };
+    const result = validate(OrgRepresentativeDelegationSchema, data);
+    expect(result.valid).toBe(true);
+    if (result.valid !== true) return;
+    const ord5Entries = result.unverified_obligations?.unverified_rules.filter((r) => r.rule_id === 'ORD-5') ?? [];
+    expect(ord5Entries.length).toBe(2);
+    const driftKeys = ord5Entries.map((e) => {
+      const match = e.evaluation_note.match(/key "([^"]+)"/);
+      return match?.[1];
+    }).sort();
+    expect(driftKeys).toEqual(['baz', 'foo']);
+  });
+
+  it('ORD-5 surfacing co-exists with ORD-3 manifest emission', () => {
+    const data = loadGenesis();
+    data.capability_scope = { 'drift_key': 'value' };
+    const result = validate(OrgRepresentativeDelegationSchema, data);
+    expect(result.valid).toBe(true);
+    if (result.valid !== true) return;
+    const ruleIds = (result.unverified_obligations?.unverified_rules ?? []).map((r) => r.rule_id).sort();
+    expect(ruleIds).toContain('ORD-3');
+    expect(ruleIds).toContain('ORD-5');
+  });
+
+  it('valid: false path (failClosed + chain absent) does NOT emit ORD-5 manifest (errors path takes precedence)', () => {
+    const data = loadGenesis();
+    data.capability_scope = { 'drift_key': 'value' };
+    const result = validate(OrgRepresentativeDelegationSchema, data, { failClosed: true });
+    expect(result.valid).toBe(false);
+    if (result.valid !== false) return;
+    expect(result.errors.some((e) => e.startsWith('CHAIN_CONTEXT_DEFERRED:'))).toBe(true);
+  });
+});

--- a/tests/governance/fr-a4-fail-closed-vectors.test.ts
+++ b/tests/governance/fr-a4-fail-closed-vectors.test.ts
@@ -41,13 +41,32 @@ interface FailClosedCase {
     failClosed?: boolean;
     chainContext?: { granted_by_chain_records?: unknown };
     acceptDeferred?: boolean;
-    now?: string;
   };
   data: unknown;
+  /**
+   * Some case files may carry an optional top-level `_fixture_note`
+   * pointing readers to the directory README; the runner does not
+   * consume it but the field is documented at the JSON schema layer.
+   */
   expected:
     | { valid: true; ord3_reason: string }
     | { valid: false; error_prefix: string };
 }
+
+const EXPECTED_CASE_IDS = new Set([
+  'case-01-default-absent-genesis',
+  'case-02-default-absent-chained',
+  'case-03-default-present-genesis',
+  'case-04-default-present-chained',
+  'case-05-default-malformed-genesis',
+  'case-06-default-malformed-chained',
+  'case-07-optin-absent-genesis',
+  'case-08-optin-absent-chained',
+  'case-09-optin-present-genesis',
+  'case-10-optin-present-chained',
+  'case-11-optin-malformed-genesis',
+  'case-12-optin-malformed-chained',
+]);
 
 function loadCases(): FailClosedCase[] {
   const files = readdirSync(FIXTURES_ROOT).filter((f) => f.endsWith('.json')).sort();
@@ -57,8 +76,15 @@ function loadCases(): FailClosedCase[] {
 describe('FR-A4 fail-closed cross-product matrix', () => {
   const cases = loadCases();
 
-  it('publishes exactly 12 fixtures (2 modes × 3 contexts × 2 record kinds)', () => {
-    expect(cases.length).toBe(12);
+  it('publishes exactly the expected 12 case_ids (2 modes × 3 contexts × 2 record kinds)', () => {
+    // F4 mitigation (PR-A3.2 iter-2): assert by case_id Set rather than count
+    // so a duplicate-and-delete failure surfaces the exact missing/extra
+    // case_id rather than a generic count mismatch.
+    const presentIds = new Set(cases.map((c) => c.case_id));
+    const missing = [...EXPECTED_CASE_IDS].filter((id) => !presentIds.has(id));
+    const extra = [...presentIds].filter((id) => !EXPECTED_CASE_IDS.has(id));
+    expect(missing, `missing case_ids: ${missing.join(', ')}`).toEqual([]);
+    expect(extra, `unexpected case_ids: ${extra.join(', ')}`).toEqual([]);
   });
 
   for (const c of cases) {

--- a/vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/README.md
+++ b/vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/README.md
@@ -81,8 +81,12 @@ needs a similar branching matrix, mint its own subdirectory (e.g.
 `vectors/<Schema>/v8.7.0-some-feature/`) with the same self-describing
 JSON shape rather than overloading this one.
 
-When adding cases, update the runner's `expect(cases.length).toBe(12)`
-assertion to the new total so accidental fixture loss is caught.
+When adding cases, add the new `case_id` to the `EXPECTED_CASE_IDS`
+Set in
+[`tests/governance/fr-a4-fail-closed-vectors.test.ts`](../../../tests/governance/fr-a4-fail-closed-vectors.test.ts).
+The runner asserts the present-on-disk case_ids exactly match the
+expected Set; a duplicate-and-delete failure surfaces the precise
+missing/extra `case_id` rather than a generic count mismatch.
 
 ## Cross-references
 

--- a/vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/README.md
+++ b/vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/README.md
@@ -1,0 +1,96 @@
+# FR-A4 fail-closed cross-product fixtures
+
+> **Scope boundary:** these fixtures exercise the `validate()`
+> `failClosed` opt-in branching (FR-A4) only. They do **not** exercise
+> chain-DAG coherence — `org_id` / `granted_by` / `delegation_id`
+> linkage between the record under validation and the chain-context
+> records is intentionally unconstrained here because `validate()`
+> defers chain-DSL evaluation (the `is_valid_dag` builtin / ORD-3
+> traversal) to `npm run check:constraints` and to consumer-side runtime
+> per ADR-010. A fixture in this directory may exhibit `org_id`
+> mismatches between the record and its chain ancestor — that is by
+> design for fail-closed branching coverage, NOT a bug in the fixture.
+
+## What these fixtures test
+
+The 12 fixtures form a 2 × 3 × 2 cross-product:
+
+- **Mode** (2): default (`failClosed` unset/false) vs. opt-in (`failClosed: true`)
+- **Chain context** (3): absent / present / malformed
+- **Record kind** (2): genesis-rooted (`granted_by: "genesis:org-public-key"`) vs. chained (`granted_by: <prior delegation_id>`)
+
+Each fixture asserts one branch of `validate()`'s decision tree:
+
+| Mode | Context | Result |
+|---|---|---|
+| default | absent / malformed | `valid:true` with ORD-3 manifest reason `context_absent` |
+| default | present | `valid:true` with ORD-3 manifest reason `pattern_matching` |
+| opt-in | absent / malformed | `valid:false` with `CHAIN_CONTEXT_DEFERRED:` error |
+| opt-in | present | `valid:true` with ORD-3 manifest reason `chain_context_provided` |
+
+## What these fixtures do NOT test
+
+- **Chain DAG validity.** `is_valid_dag` evaluation (ORD-3 chain
+  traversal, genesis-sentinel termination, depth ≤ 20) lives at
+  `npm run check:constraints` time and is not invoked by `validate()`.
+  Chain DAG coverage lives in the constraint-test suite at
+  `tests/constraints/org-representative-delegation.constraints.test.ts`,
+  not here.
+- **Cross-record `org_id` linkage.** Whether a chained record's
+  `org_id` matches its parent's `org_id` is an ORD-3 concern, not an
+  FR-A4 concern. Fixtures in this directory may use canonical record
+  payloads without re-aligning every cross-record field; the
+  fail-closed branching is what's under test.
+- **Signature verification.** ORD-1 (Ed25519 signature verification)
+  is consumer-side per NF-1; fixtures use placeholder signature bytes
+  that satisfy the schema regex but no cryptographic check.
+- **Append-only revocation.** ORD-2 is runtime-deferred and not
+  exercised here.
+
+## Fixture format
+
+Each `case-NN-mode-context-record-kind.json` file is self-describing:
+
+```json
+{
+  "case_id": "case-09-optin-present-genesis",
+  "description": "Opt-in (failClosed:true), chain context supplied, genesis record. Expected: valid:true with ORD-3 manifest reason chain_context_provided.",
+  "validate_options": {
+    "failClosed": true,
+    "chainContext": { "granted_by_chain_records": [...] }
+  },
+  "data": { /* OrgRepresentativeDelegation record */ },
+  "expected": {
+    "valid": true,
+    "ord3_reason": "chain_context_provided"
+  }
+}
+```
+
+The runner at
+[`tests/governance/fr-a4-fail-closed-vectors.test.ts`](../../../tests/governance/fr-a4-fail-closed-vectors.test.ts)
+walks this directory, asserts the count is exactly 12, and runs
+`validate(OrgRepresentativeDelegationSchema, c.data, c.validate_options)`
+against each `expected` outcome.
+
+## Adding new cases
+
+This directory's contract is **local to FR-A4**: the `_inflight_`-style
+matrix is not a generalized cross-runner convention. If a future FR
+needs a similar branching matrix, mint its own subdirectory (e.g.
+`vectors/<Schema>/v8.7.0-some-feature/`) with the same self-describing
+JSON shape rather than overloading this one.
+
+When adding cases, update the runner's `expect(cases.length).toBe(12)`
+assertion to the new total so accidental fixture loss is caught.
+
+## Cross-references
+
+- [`MIGRATION.md`](../../../MIGRATION.md) — `### FR-A4` section: full
+  consumer migration path, manifest-reason matrix, v9.0.0 default-flip
+  forward-pointer.
+- [`src/validators/index.ts`](../../../src/validators/index.ts) — the
+  `failClosed?: boolean` option and the `x-chain-bearing` metadata
+  dispatch block.
+- [`src/governance/org-representative-delegation.ts`](../../../src/governance/org-representative-delegation.ts) —
+  the schema declaring `'x-chain-bearing': true`.

--- a/vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/case-01-default-absent-genesis.json
+++ b/vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/case-01-default-absent-genesis.json
@@ -1,0 +1,47 @@
+{
+  "case_id": "case-01-default-absent-genesis",
+  "description": "Default mode (failClosed unset), no chain context, genesis-rooted record. Expected: valid:true with ORD-3 manifest reason context_absent.",
+  "validate_options": {},
+  "data": {
+    "delegation_id": "550e8400-e29b-41d4-a716-446655440501",
+    "org_id": "550e8400-e29b-41d4-a716-446655440301",
+    "representative": {
+      "agent_id": "rep-1",
+      "display_name": "Representative One",
+      "agent_type": "human",
+      "capabilities": [
+        "governance"
+      ],
+      "trust_scopes": {
+        "scopes": {},
+        "default_level": "trusted"
+      },
+      "delegation_authority": [
+        "invoke"
+      ],
+      "max_delegation_depth": 2,
+      "governance_weight": 1.0,
+      "contract_version": "8.4.0"
+    },
+    "capability_scope": {
+      "governance": "vote-and-propose"
+    },
+    "expiry": "2027-05-05T00:00:00Z",
+    "granted_by": "genesis:org-public-key",
+    "chain_depth": 0,
+    "signature": "ed25519:IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII",
+    "signed_by": "ed25519-pub:HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH",
+    "signing_key_id": "org-cold-key-2026",
+    "signing_algorithm": "ed25519",
+    "signed_at": "2026-05-05T00:00:00Z",
+    "signing_context": {
+      "audience": "550e8400-e29b-41d4-a716-446655440301",
+      "scope": "org-delegation/grant",
+      "contract_version": "8.4.0"
+    }
+  },
+  "expected": {
+    "valid": true,
+    "ord3_reason": "context_absent"
+  }
+}

--- a/vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/case-02-default-absent-chained.json
+++ b/vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/case-02-default-absent-chained.json
@@ -1,0 +1,47 @@
+{
+  "case_id": "case-02-default-absent-chained",
+  "description": "Default mode (failClosed unset), no chain context, chained record (chain_depth=1). Expected: valid:true with ORD-3 manifest reason context_absent.",
+  "validate_options": {},
+  "data": {
+    "delegation_id": "550e8400-e29b-41d4-a716-000000000502",
+    "org_id": "550e8400-e29b-41d4-a716-000000000301",
+    "representative": {
+      "agent_id": "agent-rep-1",
+      "display_name": "Agent rep-1",
+      "agent_type": "human",
+      "capabilities": [
+        "governance"
+      ],
+      "trust_scopes": {
+        "scopes": {},
+        "default_level": "trusted"
+      },
+      "delegation_authority": [
+        "invoke"
+      ],
+      "max_delegation_depth": 2,
+      "governance_weight": 1.0,
+      "contract_version": "8.4.0"
+    },
+    "capability_scope": {
+      "governance": "vote-and-propose"
+    },
+    "expiry": "2027-05-05T00:00:00Z",
+    "granted_by": "550e8400-e29b-41d4-a716-000000000501",
+    "chain_depth": 1,
+    "signature": "ed25519:JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ",
+    "signed_by": "ed25519-pub:HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH",
+    "signing_key_id": "org-cold-key-2026",
+    "signing_algorithm": "ed25519",
+    "signed_at": "2026-05-05T00:00:00Z",
+    "signing_context": {
+      "audience": "550e8400-e29b-41d4-a716-000000000301",
+      "scope": "org-delegation/grant",
+      "contract_version": "8.4.0"
+    }
+  },
+  "expected": {
+    "valid": true,
+    "ord3_reason": "context_absent"
+  }
+}

--- a/vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/case-03-default-present-genesis.json
+++ b/vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/case-03-default-present-genesis.json
@@ -1,0 +1,93 @@
+{
+  "case_id": "case-03-default-present-genesis",
+  "description": "Default mode, chain context supplied for genesis record. Expected: valid:true with ORD-3 manifest reason pattern_matching.",
+  "validate_options": {
+    "chainContext": {
+      "granted_by_chain_records": [
+        {
+          "delegation_id": "550e8400-e29b-41d4-a716-446655440501",
+          "org_id": "550e8400-e29b-41d4-a716-446655440301",
+          "representative": {
+            "agent_id": "rep-1",
+            "display_name": "Representative One",
+            "agent_type": "human",
+            "capabilities": [
+              "governance"
+            ],
+            "trust_scopes": {
+              "scopes": {},
+              "default_level": "trusted"
+            },
+            "delegation_authority": [
+              "invoke"
+            ],
+            "max_delegation_depth": 2,
+            "governance_weight": 1.0,
+            "contract_version": "8.4.0"
+          },
+          "capability_scope": {
+            "governance": "vote-and-propose"
+          },
+          "expiry": "2027-05-05T00:00:00Z",
+          "granted_by": "genesis:org-public-key",
+          "chain_depth": 0,
+          "signature": "ed25519:IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII",
+          "signed_by": "ed25519-pub:HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH",
+          "signing_key_id": "org-cold-key-2026",
+          "signing_algorithm": "ed25519",
+          "signed_at": "2026-05-05T00:00:00Z",
+          "signing_context": {
+            "audience": "550e8400-e29b-41d4-a716-446655440301",
+            "scope": "org-delegation/grant",
+            "contract_version": "8.4.0"
+          }
+        },
+        {
+          "delegation_id": "genesis:org-public-key"
+        }
+      ]
+    }
+  },
+  "data": {
+    "delegation_id": "550e8400-e29b-41d4-a716-446655440501",
+    "org_id": "550e8400-e29b-41d4-a716-446655440301",
+    "representative": {
+      "agent_id": "rep-1",
+      "display_name": "Representative One",
+      "agent_type": "human",
+      "capabilities": [
+        "governance"
+      ],
+      "trust_scopes": {
+        "scopes": {},
+        "default_level": "trusted"
+      },
+      "delegation_authority": [
+        "invoke"
+      ],
+      "max_delegation_depth": 2,
+      "governance_weight": 1.0,
+      "contract_version": "8.4.0"
+    },
+    "capability_scope": {
+      "governance": "vote-and-propose"
+    },
+    "expiry": "2027-05-05T00:00:00Z",
+    "granted_by": "genesis:org-public-key",
+    "chain_depth": 0,
+    "signature": "ed25519:IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII",
+    "signed_by": "ed25519-pub:HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH",
+    "signing_key_id": "org-cold-key-2026",
+    "signing_algorithm": "ed25519",
+    "signed_at": "2026-05-05T00:00:00Z",
+    "signing_context": {
+      "audience": "550e8400-e29b-41d4-a716-446655440301",
+      "scope": "org-delegation/grant",
+      "contract_version": "8.4.0"
+    }
+  },
+  "expected": {
+    "valid": true,
+    "ord3_reason": "pattern_matching"
+  }
+}

--- a/vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/case-04-default-present-chained.json
+++ b/vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/case-04-default-present-chained.json
@@ -127,5 +127,6 @@
   "expected": {
     "valid": true,
     "ord3_reason": "pattern_matching"
-  }
+  },
+  "_fixture_note": "See README.md §'Scope boundary' — chain-DAG coherence (cross-record org_id / granted_by linkage) is intentionally not exercised in this fail-closed branching matrix; that lives in tests/constraints/."
 }

--- a/vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/case-04-default-present-chained.json
+++ b/vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/case-04-default-present-chained.json
@@ -1,0 +1,131 @@
+{
+  "case_id": "case-04-default-present-chained",
+  "description": "Default mode, chain context supplied for chained record. Expected: valid:true with ORD-3 manifest reason pattern_matching.",
+  "validate_options": {
+    "chainContext": {
+      "granted_by_chain_records": [
+        {
+          "delegation_id": "550e8400-e29b-41d4-a716-000000000502",
+          "org_id": "550e8400-e29b-41d4-a716-000000000301",
+          "representative": {
+            "agent_id": "agent-rep-1",
+            "display_name": "Agent rep-1",
+            "agent_type": "human",
+            "capabilities": [
+              "governance"
+            ],
+            "trust_scopes": {
+              "scopes": {},
+              "default_level": "trusted"
+            },
+            "delegation_authority": [
+              "invoke"
+            ],
+            "max_delegation_depth": 2,
+            "governance_weight": 1.0,
+            "contract_version": "8.4.0"
+          },
+          "capability_scope": {
+            "governance": "vote-and-propose"
+          },
+          "expiry": "2027-05-05T00:00:00Z",
+          "granted_by": "550e8400-e29b-41d4-a716-000000000501",
+          "chain_depth": 1,
+          "signature": "ed25519:JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ",
+          "signed_by": "ed25519-pub:HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH",
+          "signing_key_id": "org-cold-key-2026",
+          "signing_algorithm": "ed25519",
+          "signed_at": "2026-05-05T00:00:00Z",
+          "signing_context": {
+            "audience": "550e8400-e29b-41d4-a716-000000000301",
+            "scope": "org-delegation/grant",
+            "contract_version": "8.4.0"
+          }
+        },
+        {
+          "delegation_id": "550e8400-e29b-41d4-a716-000000000501",
+          "org_id": "550e8400-e29b-41d4-a716-446655440301",
+          "representative": {
+            "agent_id": "rep-1",
+            "display_name": "Representative One",
+            "agent_type": "human",
+            "capabilities": [
+              "governance"
+            ],
+            "trust_scopes": {
+              "scopes": {},
+              "default_level": "trusted"
+            },
+            "delegation_authority": [
+              "invoke"
+            ],
+            "max_delegation_depth": 2,
+            "governance_weight": 1.0,
+            "contract_version": "8.4.0"
+          },
+          "capability_scope": {
+            "governance": "vote-and-propose"
+          },
+          "expiry": "2027-05-05T00:00:00Z",
+          "granted_by": "genesis:org-public-key",
+          "chain_depth": 0,
+          "signature": "ed25519:IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII",
+          "signed_by": "ed25519-pub:HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH",
+          "signing_key_id": "org-cold-key-2026",
+          "signing_algorithm": "ed25519",
+          "signed_at": "2026-05-05T00:00:00Z",
+          "signing_context": {
+            "audience": "550e8400-e29b-41d4-a716-446655440301",
+            "scope": "org-delegation/grant",
+            "contract_version": "8.4.0"
+          }
+        },
+        {
+          "delegation_id": "genesis:org-public-key"
+        }
+      ]
+    }
+  },
+  "data": {
+    "delegation_id": "550e8400-e29b-41d4-a716-000000000502",
+    "org_id": "550e8400-e29b-41d4-a716-000000000301",
+    "representative": {
+      "agent_id": "agent-rep-1",
+      "display_name": "Agent rep-1",
+      "agent_type": "human",
+      "capabilities": [
+        "governance"
+      ],
+      "trust_scopes": {
+        "scopes": {},
+        "default_level": "trusted"
+      },
+      "delegation_authority": [
+        "invoke"
+      ],
+      "max_delegation_depth": 2,
+      "governance_weight": 1.0,
+      "contract_version": "8.4.0"
+    },
+    "capability_scope": {
+      "governance": "vote-and-propose"
+    },
+    "expiry": "2027-05-05T00:00:00Z",
+    "granted_by": "550e8400-e29b-41d4-a716-000000000501",
+    "chain_depth": 1,
+    "signature": "ed25519:JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ",
+    "signed_by": "ed25519-pub:HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH",
+    "signing_key_id": "org-cold-key-2026",
+    "signing_algorithm": "ed25519",
+    "signed_at": "2026-05-05T00:00:00Z",
+    "signing_context": {
+      "audience": "550e8400-e29b-41d4-a716-000000000301",
+      "scope": "org-delegation/grant",
+      "contract_version": "8.4.0"
+    }
+  },
+  "expected": {
+    "valid": true,
+    "ord3_reason": "pattern_matching"
+  }
+}

--- a/vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/case-05-default-malformed-genesis.json
+++ b/vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/case-05-default-malformed-genesis.json
@@ -1,0 +1,51 @@
+{
+  "case_id": "case-05-default-malformed-genesis",
+  "description": "Default mode, chainContext present but granted_by_chain_records is not an array. Expected: valid:true with ORD-3 manifest reason context_absent (malformed treated as absent per hasChainContextRecords).",
+  "validate_options": {
+    "chainContext": {
+      "granted_by_chain_records": "not-an-array"
+    }
+  },
+  "data": {
+    "delegation_id": "550e8400-e29b-41d4-a716-446655440501",
+    "org_id": "550e8400-e29b-41d4-a716-446655440301",
+    "representative": {
+      "agent_id": "rep-1",
+      "display_name": "Representative One",
+      "agent_type": "human",
+      "capabilities": [
+        "governance"
+      ],
+      "trust_scopes": {
+        "scopes": {},
+        "default_level": "trusted"
+      },
+      "delegation_authority": [
+        "invoke"
+      ],
+      "max_delegation_depth": 2,
+      "governance_weight": 1.0,
+      "contract_version": "8.4.0"
+    },
+    "capability_scope": {
+      "governance": "vote-and-propose"
+    },
+    "expiry": "2027-05-05T00:00:00Z",
+    "granted_by": "genesis:org-public-key",
+    "chain_depth": 0,
+    "signature": "ed25519:IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII",
+    "signed_by": "ed25519-pub:HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH",
+    "signing_key_id": "org-cold-key-2026",
+    "signing_algorithm": "ed25519",
+    "signed_at": "2026-05-05T00:00:00Z",
+    "signing_context": {
+      "audience": "550e8400-e29b-41d4-a716-446655440301",
+      "scope": "org-delegation/grant",
+      "contract_version": "8.4.0"
+    }
+  },
+  "expected": {
+    "valid": true,
+    "ord3_reason": "context_absent"
+  }
+}

--- a/vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/case-06-default-malformed-chained.json
+++ b/vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/case-06-default-malformed-chained.json
@@ -1,0 +1,51 @@
+{
+  "case_id": "case-06-default-malformed-chained",
+  "description": "Default mode, chainContext present but malformed; chained record. Expected: valid:true with ORD-3 manifest reason context_absent.",
+  "validate_options": {
+    "chainContext": {
+      "granted_by_chain_records": "not-an-array"
+    }
+  },
+  "data": {
+    "delegation_id": "550e8400-e29b-41d4-a716-000000000502",
+    "org_id": "550e8400-e29b-41d4-a716-000000000301",
+    "representative": {
+      "agent_id": "agent-rep-1",
+      "display_name": "Agent rep-1",
+      "agent_type": "human",
+      "capabilities": [
+        "governance"
+      ],
+      "trust_scopes": {
+        "scopes": {},
+        "default_level": "trusted"
+      },
+      "delegation_authority": [
+        "invoke"
+      ],
+      "max_delegation_depth": 2,
+      "governance_weight": 1.0,
+      "contract_version": "8.4.0"
+    },
+    "capability_scope": {
+      "governance": "vote-and-propose"
+    },
+    "expiry": "2027-05-05T00:00:00Z",
+    "granted_by": "550e8400-e29b-41d4-a716-000000000501",
+    "chain_depth": 1,
+    "signature": "ed25519:JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ",
+    "signed_by": "ed25519-pub:HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH",
+    "signing_key_id": "org-cold-key-2026",
+    "signing_algorithm": "ed25519",
+    "signed_at": "2026-05-05T00:00:00Z",
+    "signing_context": {
+      "audience": "550e8400-e29b-41d4-a716-000000000301",
+      "scope": "org-delegation/grant",
+      "contract_version": "8.4.0"
+    }
+  },
+  "expected": {
+    "valid": true,
+    "ord3_reason": "context_absent"
+  }
+}

--- a/vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/case-07-optin-absent-genesis.json
+++ b/vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/case-07-optin-absent-genesis.json
@@ -1,0 +1,49 @@
+{
+  "case_id": "case-07-optin-absent-genesis",
+  "description": "Opt-in (failClosed:true), no chain context, genesis record. Expected: valid:false with CHAIN_CONTEXT_DEFERRED error.",
+  "validate_options": {
+    "failClosed": true
+  },
+  "data": {
+    "delegation_id": "550e8400-e29b-41d4-a716-446655440501",
+    "org_id": "550e8400-e29b-41d4-a716-446655440301",
+    "representative": {
+      "agent_id": "rep-1",
+      "display_name": "Representative One",
+      "agent_type": "human",
+      "capabilities": [
+        "governance"
+      ],
+      "trust_scopes": {
+        "scopes": {},
+        "default_level": "trusted"
+      },
+      "delegation_authority": [
+        "invoke"
+      ],
+      "max_delegation_depth": 2,
+      "governance_weight": 1.0,
+      "contract_version": "8.4.0"
+    },
+    "capability_scope": {
+      "governance": "vote-and-propose"
+    },
+    "expiry": "2027-05-05T00:00:00Z",
+    "granted_by": "genesis:org-public-key",
+    "chain_depth": 0,
+    "signature": "ed25519:IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII",
+    "signed_by": "ed25519-pub:HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH",
+    "signing_key_id": "org-cold-key-2026",
+    "signing_algorithm": "ed25519",
+    "signed_at": "2026-05-05T00:00:00Z",
+    "signing_context": {
+      "audience": "550e8400-e29b-41d4-a716-446655440301",
+      "scope": "org-delegation/grant",
+      "contract_version": "8.4.0"
+    }
+  },
+  "expected": {
+    "valid": false,
+    "error_prefix": "CHAIN_CONTEXT_DEFERRED:"
+  }
+}

--- a/vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/case-08-optin-absent-chained.json
+++ b/vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/case-08-optin-absent-chained.json
@@ -1,0 +1,49 @@
+{
+  "case_id": "case-08-optin-absent-chained",
+  "description": "Opt-in (failClosed:true), no chain context, chained record. Expected: valid:false with CHAIN_CONTEXT_DEFERRED error.",
+  "validate_options": {
+    "failClosed": true
+  },
+  "data": {
+    "delegation_id": "550e8400-e29b-41d4-a716-000000000502",
+    "org_id": "550e8400-e29b-41d4-a716-000000000301",
+    "representative": {
+      "agent_id": "agent-rep-1",
+      "display_name": "Agent rep-1",
+      "agent_type": "human",
+      "capabilities": [
+        "governance"
+      ],
+      "trust_scopes": {
+        "scopes": {},
+        "default_level": "trusted"
+      },
+      "delegation_authority": [
+        "invoke"
+      ],
+      "max_delegation_depth": 2,
+      "governance_weight": 1.0,
+      "contract_version": "8.4.0"
+    },
+    "capability_scope": {
+      "governance": "vote-and-propose"
+    },
+    "expiry": "2027-05-05T00:00:00Z",
+    "granted_by": "550e8400-e29b-41d4-a716-000000000501",
+    "chain_depth": 1,
+    "signature": "ed25519:JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ",
+    "signed_by": "ed25519-pub:HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH",
+    "signing_key_id": "org-cold-key-2026",
+    "signing_algorithm": "ed25519",
+    "signed_at": "2026-05-05T00:00:00Z",
+    "signing_context": {
+      "audience": "550e8400-e29b-41d4-a716-000000000301",
+      "scope": "org-delegation/grant",
+      "contract_version": "8.4.0"
+    }
+  },
+  "expected": {
+    "valid": false,
+    "error_prefix": "CHAIN_CONTEXT_DEFERRED:"
+  }
+}

--- a/vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/case-09-optin-present-genesis.json
+++ b/vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/case-09-optin-present-genesis.json
@@ -1,0 +1,94 @@
+{
+  "case_id": "case-09-optin-present-genesis",
+  "description": "Opt-in (failClosed:true), chain context supplied, genesis record. Expected: valid:true with ORD-3 manifest reason chain_context_provided.",
+  "validate_options": {
+    "failClosed": true,
+    "chainContext": {
+      "granted_by_chain_records": [
+        {
+          "delegation_id": "550e8400-e29b-41d4-a716-446655440501",
+          "org_id": "550e8400-e29b-41d4-a716-446655440301",
+          "representative": {
+            "agent_id": "rep-1",
+            "display_name": "Representative One",
+            "agent_type": "human",
+            "capabilities": [
+              "governance"
+            ],
+            "trust_scopes": {
+              "scopes": {},
+              "default_level": "trusted"
+            },
+            "delegation_authority": [
+              "invoke"
+            ],
+            "max_delegation_depth": 2,
+            "governance_weight": 1.0,
+            "contract_version": "8.4.0"
+          },
+          "capability_scope": {
+            "governance": "vote-and-propose"
+          },
+          "expiry": "2027-05-05T00:00:00Z",
+          "granted_by": "genesis:org-public-key",
+          "chain_depth": 0,
+          "signature": "ed25519:IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII",
+          "signed_by": "ed25519-pub:HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH",
+          "signing_key_id": "org-cold-key-2026",
+          "signing_algorithm": "ed25519",
+          "signed_at": "2026-05-05T00:00:00Z",
+          "signing_context": {
+            "audience": "550e8400-e29b-41d4-a716-446655440301",
+            "scope": "org-delegation/grant",
+            "contract_version": "8.4.0"
+          }
+        },
+        {
+          "delegation_id": "genesis:org-public-key"
+        }
+      ]
+    }
+  },
+  "data": {
+    "delegation_id": "550e8400-e29b-41d4-a716-446655440501",
+    "org_id": "550e8400-e29b-41d4-a716-446655440301",
+    "representative": {
+      "agent_id": "rep-1",
+      "display_name": "Representative One",
+      "agent_type": "human",
+      "capabilities": [
+        "governance"
+      ],
+      "trust_scopes": {
+        "scopes": {},
+        "default_level": "trusted"
+      },
+      "delegation_authority": [
+        "invoke"
+      ],
+      "max_delegation_depth": 2,
+      "governance_weight": 1.0,
+      "contract_version": "8.4.0"
+    },
+    "capability_scope": {
+      "governance": "vote-and-propose"
+    },
+    "expiry": "2027-05-05T00:00:00Z",
+    "granted_by": "genesis:org-public-key",
+    "chain_depth": 0,
+    "signature": "ed25519:IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII",
+    "signed_by": "ed25519-pub:HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH",
+    "signing_key_id": "org-cold-key-2026",
+    "signing_algorithm": "ed25519",
+    "signed_at": "2026-05-05T00:00:00Z",
+    "signing_context": {
+      "audience": "550e8400-e29b-41d4-a716-446655440301",
+      "scope": "org-delegation/grant",
+      "contract_version": "8.4.0"
+    }
+  },
+  "expected": {
+    "valid": true,
+    "ord3_reason": "chain_context_provided"
+  }
+}

--- a/vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/case-10-optin-present-chained.json
+++ b/vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/case-10-optin-present-chained.json
@@ -128,5 +128,6 @@
   "expected": {
     "valid": true,
     "ord3_reason": "chain_context_provided"
-  }
+  },
+  "_fixture_note": "See README.md §'Scope boundary' — chain-DAG coherence (cross-record org_id / granted_by linkage) is intentionally not exercised in this fail-closed branching matrix; that lives in tests/constraints/."
 }

--- a/vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/case-10-optin-present-chained.json
+++ b/vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/case-10-optin-present-chained.json
@@ -1,0 +1,132 @@
+{
+  "case_id": "case-10-optin-present-chained",
+  "description": "Opt-in (failClosed:true), chain context supplied, chained record. Expected: valid:true with ORD-3 manifest reason chain_context_provided.",
+  "validate_options": {
+    "failClosed": true,
+    "chainContext": {
+      "granted_by_chain_records": [
+        {
+          "delegation_id": "550e8400-e29b-41d4-a716-000000000502",
+          "org_id": "550e8400-e29b-41d4-a716-000000000301",
+          "representative": {
+            "agent_id": "agent-rep-1",
+            "display_name": "Agent rep-1",
+            "agent_type": "human",
+            "capabilities": [
+              "governance"
+            ],
+            "trust_scopes": {
+              "scopes": {},
+              "default_level": "trusted"
+            },
+            "delegation_authority": [
+              "invoke"
+            ],
+            "max_delegation_depth": 2,
+            "governance_weight": 1.0,
+            "contract_version": "8.4.0"
+          },
+          "capability_scope": {
+            "governance": "vote-and-propose"
+          },
+          "expiry": "2027-05-05T00:00:00Z",
+          "granted_by": "550e8400-e29b-41d4-a716-000000000501",
+          "chain_depth": 1,
+          "signature": "ed25519:JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ",
+          "signed_by": "ed25519-pub:HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH",
+          "signing_key_id": "org-cold-key-2026",
+          "signing_algorithm": "ed25519",
+          "signed_at": "2026-05-05T00:00:00Z",
+          "signing_context": {
+            "audience": "550e8400-e29b-41d4-a716-000000000301",
+            "scope": "org-delegation/grant",
+            "contract_version": "8.4.0"
+          }
+        },
+        {
+          "delegation_id": "550e8400-e29b-41d4-a716-000000000501",
+          "org_id": "550e8400-e29b-41d4-a716-446655440301",
+          "representative": {
+            "agent_id": "rep-1",
+            "display_name": "Representative One",
+            "agent_type": "human",
+            "capabilities": [
+              "governance"
+            ],
+            "trust_scopes": {
+              "scopes": {},
+              "default_level": "trusted"
+            },
+            "delegation_authority": [
+              "invoke"
+            ],
+            "max_delegation_depth": 2,
+            "governance_weight": 1.0,
+            "contract_version": "8.4.0"
+          },
+          "capability_scope": {
+            "governance": "vote-and-propose"
+          },
+          "expiry": "2027-05-05T00:00:00Z",
+          "granted_by": "genesis:org-public-key",
+          "chain_depth": 0,
+          "signature": "ed25519:IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII",
+          "signed_by": "ed25519-pub:HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH",
+          "signing_key_id": "org-cold-key-2026",
+          "signing_algorithm": "ed25519",
+          "signed_at": "2026-05-05T00:00:00Z",
+          "signing_context": {
+            "audience": "550e8400-e29b-41d4-a716-446655440301",
+            "scope": "org-delegation/grant",
+            "contract_version": "8.4.0"
+          }
+        },
+        {
+          "delegation_id": "genesis:org-public-key"
+        }
+      ]
+    }
+  },
+  "data": {
+    "delegation_id": "550e8400-e29b-41d4-a716-000000000502",
+    "org_id": "550e8400-e29b-41d4-a716-000000000301",
+    "representative": {
+      "agent_id": "agent-rep-1",
+      "display_name": "Agent rep-1",
+      "agent_type": "human",
+      "capabilities": [
+        "governance"
+      ],
+      "trust_scopes": {
+        "scopes": {},
+        "default_level": "trusted"
+      },
+      "delegation_authority": [
+        "invoke"
+      ],
+      "max_delegation_depth": 2,
+      "governance_weight": 1.0,
+      "contract_version": "8.4.0"
+    },
+    "capability_scope": {
+      "governance": "vote-and-propose"
+    },
+    "expiry": "2027-05-05T00:00:00Z",
+    "granted_by": "550e8400-e29b-41d4-a716-000000000501",
+    "chain_depth": 1,
+    "signature": "ed25519:JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ",
+    "signed_by": "ed25519-pub:HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH",
+    "signing_key_id": "org-cold-key-2026",
+    "signing_algorithm": "ed25519",
+    "signed_at": "2026-05-05T00:00:00Z",
+    "signing_context": {
+      "audience": "550e8400-e29b-41d4-a716-000000000301",
+      "scope": "org-delegation/grant",
+      "contract_version": "8.4.0"
+    }
+  },
+  "expected": {
+    "valid": true,
+    "ord3_reason": "chain_context_provided"
+  }
+}

--- a/vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/case-11-optin-malformed-genesis.json
+++ b/vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/case-11-optin-malformed-genesis.json
@@ -1,0 +1,52 @@
+{
+  "case_id": "case-11-optin-malformed-genesis",
+  "description": "Opt-in (failClosed:true), chainContext present but malformed (granted_by_chain_records not an array), genesis record. Expected: valid:false with CHAIN_CONTEXT_DEFERRED error (malformed counts as absent).",
+  "validate_options": {
+    "failClosed": true,
+    "chainContext": {
+      "granted_by_chain_records": "not-an-array"
+    }
+  },
+  "data": {
+    "delegation_id": "550e8400-e29b-41d4-a716-446655440501",
+    "org_id": "550e8400-e29b-41d4-a716-446655440301",
+    "representative": {
+      "agent_id": "rep-1",
+      "display_name": "Representative One",
+      "agent_type": "human",
+      "capabilities": [
+        "governance"
+      ],
+      "trust_scopes": {
+        "scopes": {},
+        "default_level": "trusted"
+      },
+      "delegation_authority": [
+        "invoke"
+      ],
+      "max_delegation_depth": 2,
+      "governance_weight": 1.0,
+      "contract_version": "8.4.0"
+    },
+    "capability_scope": {
+      "governance": "vote-and-propose"
+    },
+    "expiry": "2027-05-05T00:00:00Z",
+    "granted_by": "genesis:org-public-key",
+    "chain_depth": 0,
+    "signature": "ed25519:IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII",
+    "signed_by": "ed25519-pub:HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH",
+    "signing_key_id": "org-cold-key-2026",
+    "signing_algorithm": "ed25519",
+    "signed_at": "2026-05-05T00:00:00Z",
+    "signing_context": {
+      "audience": "550e8400-e29b-41d4-a716-446655440301",
+      "scope": "org-delegation/grant",
+      "contract_version": "8.4.0"
+    }
+  },
+  "expected": {
+    "valid": false,
+    "error_prefix": "CHAIN_CONTEXT_DEFERRED:"
+  }
+}

--- a/vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/case-12-optin-malformed-chained.json
+++ b/vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/case-12-optin-malformed-chained.json
@@ -1,0 +1,52 @@
+{
+  "case_id": "case-12-optin-malformed-chained",
+  "description": "Opt-in (failClosed:true), chainContext present but malformed, chained record. Expected: valid:false with CHAIN_CONTEXT_DEFERRED error.",
+  "validate_options": {
+    "failClosed": true,
+    "chainContext": {
+      "granted_by_chain_records": "not-an-array"
+    }
+  },
+  "data": {
+    "delegation_id": "550e8400-e29b-41d4-a716-000000000502",
+    "org_id": "550e8400-e29b-41d4-a716-000000000301",
+    "representative": {
+      "agent_id": "agent-rep-1",
+      "display_name": "Agent rep-1",
+      "agent_type": "human",
+      "capabilities": [
+        "governance"
+      ],
+      "trust_scopes": {
+        "scopes": {},
+        "default_level": "trusted"
+      },
+      "delegation_authority": [
+        "invoke"
+      ],
+      "max_delegation_depth": 2,
+      "governance_weight": 1.0,
+      "contract_version": "8.4.0"
+    },
+    "capability_scope": {
+      "governance": "vote-and-propose"
+    },
+    "expiry": "2027-05-05T00:00:00Z",
+    "granted_by": "550e8400-e29b-41d4-a716-000000000501",
+    "chain_depth": 1,
+    "signature": "ed25519:JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ",
+    "signed_by": "ed25519-pub:HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH",
+    "signing_key_id": "org-cold-key-2026",
+    "signing_algorithm": "ed25519",
+    "signed_at": "2026-05-05T00:00:00Z",
+    "signing_context": {
+      "audience": "550e8400-e29b-41d4-a716-000000000301",
+      "scope": "org-delegation/grant",
+      "contract_version": "8.4.0"
+    }
+  },
+  "expected": {
+    "valid": false,
+    "error_prefix": "CHAIN_CONTEXT_DEFERRED:"
+  }
+}


### PR DESCRIPTION
## Summary

- **FR-A4 (ORD-3 fail-closed opt-in):** Adds `failClosed?: boolean` option to `validate()` and `'x-chain-bearing': true` schema-metadata flag on `OrgRepresentativeDelegationSchema`. When opted-in, chain-context-absent records hard-reject with `CHAIN_CONTEXT_DEFERRED:` error; chain-context-present records receive a manifest entry with the new `'chain_context_provided'` reason. Default `validate()` behavior is byte-identical to v8.5.x per NFR-1. Generalizes the v8.5.0 ORD-3 manifest emission from `$id`-keyed to metadata-driven, mirroring the existing `x-crypto-bearing` / `x-integrity-bearing` patterns.

- **FR-A3 (ORD-5 vocabulary-drift surfacing):** Surfaces ORD-5 (`capability_scope` keys outside the canonical `CAPABILITY_SCOPES` set: `billing | governance | inference | delegation | audit | composition`) at `validate()` time. Each non-canonical key emits one manifest entry with `reason: 'vocabulary_drift'` and `evaluator: 'library'`. Severity stays `warning` for the cycle-005 soak window; promotion to error is a PR-A3.10 decision per soak telemetry. Each manifest's `manifest_emitted_at` timestamp gives consumers the per-fire signal for windowed aggregation.

- **MIGRATION.md** adds new `### FR-A4` and `### FR-A3` sections documenting the opt-in contract, the manifest-reason matrix, the three-step consumer migration path, and the v9.0.0 default-flip forward-pointer. Top-of-section status callout widened to `FR-A5 + FR-A4 + FR-A3`.

- **12 cross-product fixtures** under `vectors/OrgRepresentativeDelegation/v8.6.0-fail-closed/` (2 modes × 3 chain-contexts × 2 record-kinds). Self-describing case format with `case_id`, `description`, `validate_options`, `data`, and `expected` outcome. Picked up by a new `tests/governance/fr-a4-fail-closed-vectors.test.ts` runner.

## Test plan

- [x] `npm run check:all` exit 0
- [x] `npm run semver:check` exit 0 (baseline mode — version bump locked to v8.6.0 ship PR)
- [x] `npx vitest run` — 7,816 → 7,836 passing (+20 net, exactly matching the 20 new tests)
- [x] `npx vitest run tests/governance/fr-a4-fail-closed-vectors.test.ts` — 20/20 pass
- [x] Existing 7,816 tests continue to pass — default `validate()` behavior unchanged (NFR-1)
- [x] Existing canonical fixtures (using `governance` scope) emit no ORD-5 entries — strict-additive contract preserved
- [x] `npm run schema:generate` regenerates `schemas/org-representative-delegation.schema.json` to include `x-chain-bearing: true`
- [x] Pollution grep (canonical hook regex) on the staged diff: CLEAN
- [ ] CI workflows (`ci.yml` + `pollution-check.yml`) green on PR

## Sprint reference

- Sprint plan: `grimoires/loa/sprint.md` §1 PR-A3.2
- Reviewer report: `grimoires/loa/a2a/sprint-A3.2/reviewer.md`
- FR coverage: FR-A4, FR-A3
- Predecessor: PR-A3.1 (`67916d1d`)