### PR TITLE
feat(cycle-005): PR-A3.3 — FR-C1/C2/C3 state-bearing constraint builtins

### DIFF
--- a/schemas/index.json
+++ b/schemas/index.json
@@ -2,7 +2,7 @@
   "$schema": "https://schemas.0xhoneyjar.com/loa-hounfour/index",
   "version": "8.5.2",
   "min_supported_version": "6.0.0",
-  "generated_at": "2026-05-08T11:39:03.346Z",
+  "generated_at": "2026-05-08T12:40:18.524Z",
   "schemas": [
     {
       "name": "jwt-claims",

--- a/src/constraints/builtins/chain-validator-prev-hash.ts
+++ b/src/constraints/builtins/chain-validator-prev-hash.ts
@@ -141,6 +141,25 @@ export function evaluateChainValidatorPrevHash(
     };
   }
 
+  // F-002 mitigation (iter-1 HIGH): runtime shape validation for state.
+  // TypeScript's "ReadonlyMap" type evaporates at runtime; a consumer
+  // passing a plain object or null would throw on `.get` and bypass the
+  // structured CHAIN_INVALID_INPUT diagnostic. Validate the shape before
+  // any field access.
+  if (state !== undefined && !(state.expected_prior_hash instanceof Map)) {
+    return {
+      valid: false,
+      diagnostic: {
+        code: 'CHAIN_INVALID_INPUT',
+        message:
+          'chain_validator_prev_hash: state.expected_prior_hash must be a Map ' +
+          'instance. Consumer-supplied state crosses a trust boundary; the ' +
+          'library validates the runtime shape rather than relying on ' +
+          'TypeScript type erasure.',
+      },
+    };
+  }
+
   if (state === undefined) {
     return {
       valid: true,
@@ -236,6 +255,19 @@ export function evaluateChainValidatorPrevHash(
     // this index MUST match the chain's on-payload previous_hash. When the
     // ledger has no entry for this index, no cross-check fires (the
     // consumer hasn't recorded an expectation yet).
+    //
+    // Ordering rationale (iter-1 LOW F5): chain-internal checks
+    // (CHAIN_PREV_HASH_MISMATCH, CHAIN_GENESIS_VIOLATION) fire BEFORE the
+    // NA-1 cross-check. Rationale: if the chain itself is internally
+    // inconsistent, the on-payload `previous_hash` is already untrustworthy
+    // and comparing it against the audit ledger would produce a misleading
+    // `CHAIN_LEDGER_MISMATCH` (the chain might "match" the ledger by
+    // coincidence even though it's broken). Surfacing the structural break
+    // first gives operators the right signal: "this chain is malformed"
+    // rather than "this chain disagrees with the ledger." Forensic triage
+    // for tampering signals can still be reached by re-running with the
+    // chain-internal break repaired; the NA-1 path then surfaces the
+    // remaining ledger divergence.
     const expectedPriorHash = state.expected_prior_hash.get(i);
     if (expectedPriorHash !== undefined && expectedPriorHash !== previousHash) {
       return {

--- a/src/constraints/builtins/chain-validator-prev-hash.ts
+++ b/src/constraints/builtins/chain-validator-prev-hash.ts
@@ -1,0 +1,259 @@
+/**
+ * `chain_validator_prev_hash` constraint builtin (FR-C3, v8.6.0).
+ *
+ * Ledger-style chain validity check. Asserts (1) the validating record's
+ * `previous_hash` field correctly references its predecessor's
+ * `entry_hash`, (2) the chain terminates at a genesis-sentinel anchor,
+ * AND (3) the audit-ledger's recorded `expected_prior_hash` for this
+ * record matches the on-chain `previous_hash` value (NA-1).
+ *
+ * **Distinct from ORD-3.** ORD-3 (`is_valid_dag`, FR-A4 schema-flagged)
+ * validates the *delegation* chain: a directed acyclic graph keyed by
+ * `delegation_id` with `granted_by` edges terminating at the literal
+ * sentinel `"genesis:org-public-key"`. FR-C3 instead validates a
+ * *cluster-event* ledger chain: a linear chain of records each carrying
+ * `entry_hash` + `previous_hash`, anchored at a per-cluster genesis
+ * sentinel. Different shapes, different sentinels, different invariants.
+ *
+ * **Genesis sentinel.** The first record in a cluster-event chain
+ * carries `previous_hash == "genesis:cluster-ledger"` (or the
+ * cluster-specific genesis declared by `state.genesis_hash`). This is a
+ * free parameter of the builtin so different cluster types can use
+ * different genesis encodings; the default sentinel is documented but
+ * not hard-coded.
+ *
+ * **NA-1 expected_prior_hash usage.** The audit-ledger surface (the
+ * consumer's persistent record of what the chain *should* look like)
+ * carries an `expected_prior_hash` field per logical chain position.
+ * NA-1 (cycle-005 RC2 patch) closed the gap where this field was
+ * declared but never cross-checked. This builtin fires
+ * `CHAIN_LEDGER_MISMATCH` when the chain's on-payload `previous_hash`
+ * differs from the audit-ledger's `expected_prior_hash` — the divergence
+ * surfaces a tampered chain or a misaligned audit ledger.
+ *
+ * **Three failure modes:**
+ *   - `CHAIN_PREV_HASH_MISMATCH` — within the supplied chain, a record's
+ *     `previous_hash` does not equal its predecessor's `entry_hash`.
+ *   - `CHAIN_LEDGER_MISMATCH` — the consumer's audit-ledger expectation
+ *     diverges from the chain's actual `previous_hash` (NA-1).
+ *   - `CHAIN_GENESIS_VIOLATION` — the chain's first record's
+ *     `previous_hash` does not equal the configured genesis sentinel.
+ *
+ * **One deferred mode:**
+ *   - `CHAIN_CONTEXT_DEFERRED` — chain context not supplied; obligation
+ *     deferred to consumer (mirrors the ORD-3 deferral via the existing
+ *     `'context_absent'` reason; this builtin uses the more specific
+ *     `'CHAIN_CONTEXT_DEFERRED'` code in its diagnostic surface).
+ *
+ * @see SDD section 5.5.4 — Cluster-event ledger chain (NORMATIVE)
+ * @see PR-A2.3 §ORD-3 — companion delegation-chain DAG check (different shape)
+ * @since v8.6.0 — FR-C3 (with NA-1)
+ */
+
+/**
+ * Default genesis-sentinel string for cluster-event ledger chains. The
+ * sentinel is consumer-overridable via `state.genesis_hash` so different
+ * cluster types can use different encodings; the default is documented
+ * but not load-bearing. Distinct from the ORD-3 delegation-chain
+ * sentinel (`"genesis:org-public-key"`).
+ */
+export const DEFAULT_LEDGER_GENESIS_SENTINEL = 'genesis:cluster-ledger';
+
+export type ChainValidatorErrorCode =
+  | 'CHAIN_PREV_HASH_MISMATCH'
+  | 'CHAIN_LEDGER_MISMATCH'
+  | 'CHAIN_GENESIS_VIOLATION'
+  | 'CHAIN_CONTEXT_DEFERRED'
+  | 'CHAIN_INVALID_INPUT';
+
+export interface ChainValidatorDiagnostic {
+  code: ChainValidatorErrorCode;
+  message: string;
+  /** Index in the supplied chain where the violation surfaced. */
+  chain_index?: number;
+  /** Hash value the chain itself recorded. */
+  chain_value?: string;
+  /** Hash value the audit ledger expected (NA-1 surface). */
+  expected_value?: string;
+}
+
+/**
+ * Cluster-event ledger chain state supplied by the consumer. The chain
+ * itself is an array of records; the audit-ledger expected_prior_hash
+ * map carries the consumer's persistent expectation per chain index
+ * (NA-1 surface).
+ */
+export interface ChainLedgerState {
+  /**
+   * Genesis-sentinel value the chain's first record's `previous_hash`
+   * MUST equal. Defaults to `DEFAULT_LEDGER_GENESIS_SENTINEL` when
+   * unset.
+   */
+  genesis_hash?: string;
+  /**
+   * Audit-ledger surface: maps chain_index → expected previous_hash
+   * value. NA-1 cross-check fires when this map's value at index `i`
+   * differs from the chain's record's `previous_hash` at the same
+   * index.
+   */
+  expected_prior_hash: ReadonlyMap<number, string>;
+}
+
+export interface EvaluateChainValidatorPrevHashResult {
+  valid: boolean;
+  diagnostic?: ChainValidatorDiagnostic;
+}
+
+/**
+ * Standalone evaluator. The constraint-DSL wrapper at
+ * `src/constraints/evaluator.ts` `parseChainValidatorPrevHash()` returns
+ * a boolean; direct callers wanting the structured diagnostic should
+ * use this entry point.
+ *
+ * Argument shape:
+ *   `chain_validator_prev_hash(chain, entry_hash_field, previous_hash_field, state?)`
+ *
+ * @param chain - Array of cluster-event records, ordered from genesis-
+ *                rooted to most-recent. Each record MUST contain string-
+ *                typed `entry_hash_field` and `previous_hash_field`
+ *                values.
+ * @param entryHashField - Field name on each record carrying that
+ *                         record's own hash.
+ * @param previousHashField - Field name on each record carrying the
+ *                            hash of the previous record (or the genesis
+ *                            sentinel for the first record).
+ * @param state - Audit-ledger state. When `undefined`, the diagnostic is
+ *                `CHAIN_CONTEXT_DEFERRED` and `valid: true`.
+ */
+export function evaluateChainValidatorPrevHash(
+  chain: unknown,
+  entryHashField: string,
+  previousHashField: string,
+  state: ChainLedgerState | undefined,
+): EvaluateChainValidatorPrevHashResult {
+  if (!Array.isArray(chain)) {
+    return {
+      valid: false,
+      diagnostic: {
+        code: 'CHAIN_INVALID_INPUT',
+        message: 'chain_validator_prev_hash: chain argument must be an array',
+      },
+    };
+  }
+
+  if (state === undefined) {
+    return {
+      valid: true,
+      diagnostic: {
+        code: 'CHAIN_CONTEXT_DEFERRED',
+        message:
+          'chain_validator_prev_hash: audit-ledger state was not supplied via ' +
+          'validate() options.chainLedger. The obligation is deferred to ' +
+          'consumer-side evaluation; the consumer MUST cross-check each ' +
+          'record\'s previous_hash against (a) the predecessor\'s entry_hash ' +
+          'and (b) their persistent audit-ledger\'s expected_prior_hash.',
+      },
+    };
+  }
+
+  // Empty chain: nothing to validate.
+  if (chain.length === 0) {
+    return { valid: true };
+  }
+
+  const genesisSentinel = state.genesis_hash ?? DEFAULT_LEDGER_GENESIS_SENTINEL;
+
+  for (let i = 0; i < chain.length; i++) {
+    const record = chain[i];
+    if (record === null || typeof record !== 'object' || Array.isArray(record)) {
+      return {
+        valid: false,
+        diagnostic: {
+          code: 'CHAIN_INVALID_INPUT',
+          message:
+            `chain_validator_prev_hash: chain[${i}] must be a non-array object`,
+          chain_index: i,
+        },
+      };
+    }
+    const rec = record as Record<string, unknown>;
+    const entryHash = rec[entryHashField];
+    const previousHash = rec[previousHashField];
+    if (typeof entryHash !== 'string' || typeof previousHash !== 'string') {
+      return {
+        valid: false,
+        diagnostic: {
+          code: 'CHAIN_INVALID_INPUT',
+          message:
+            `chain_validator_prev_hash: chain[${i}] must carry string-typed ` +
+            `${entryHashField} and ${previousHashField} values`,
+          chain_index: i,
+        },
+      };
+    }
+
+    // Genesis position (first record).
+    if (i === 0) {
+      if (previousHash !== genesisSentinel) {
+        return {
+          valid: false,
+          diagnostic: {
+            code: 'CHAIN_GENESIS_VIOLATION',
+            message:
+              `chain_validator_prev_hash: chain[0].${previousHashField} = ` +
+              `"${previousHash}" but genesis sentinel is "${genesisSentinel}". ` +
+              'The first record in a cluster-event ledger chain MUST anchor at ' +
+              'the configured genesis sentinel.',
+            chain_index: 0,
+            chain_value: previousHash,
+            expected_value: genesisSentinel,
+          },
+        };
+      }
+    } else {
+      // Successor position: previous_hash must equal predecessor's entry_hash.
+      const predecessor = chain[i - 1] as Record<string, unknown>;
+      const predecessorEntryHash = predecessor[entryHashField] as string;
+      if (previousHash !== predecessorEntryHash) {
+        return {
+          valid: false,
+          diagnostic: {
+            code: 'CHAIN_PREV_HASH_MISMATCH',
+            message:
+              `chain_validator_prev_hash: chain[${i}].${previousHashField} = ` +
+              `"${previousHash}" but chain[${i - 1}].${entryHashField} = ` +
+              `"${predecessorEntryHash}". The chain link is broken — the record ` +
+              'has been tampered or the chain has been assembled wrong.',
+            chain_index: i,
+            chain_value: previousHash,
+            expected_value: predecessorEntryHash,
+          },
+        };
+      }
+    }
+
+    // NA-1 audit-ledger cross-check: the consumer's expected_prior_hash for
+    // this index MUST match the chain's on-payload previous_hash. When the
+    // ledger has no entry for this index, no cross-check fires (the
+    // consumer hasn't recorded an expectation yet).
+    const expectedPriorHash = state.expected_prior_hash.get(i);
+    if (expectedPriorHash !== undefined && expectedPriorHash !== previousHash) {
+      return {
+        valid: false,
+        diagnostic: {
+          code: 'CHAIN_LEDGER_MISMATCH',
+          message:
+            `chain_validator_prev_hash: chain[${i}].${previousHashField} = ` +
+            `"${previousHash}" but the audit ledger expected ` +
+            `"${expectedPriorHash}" at this index. The chain payload diverges ` +
+            'from the consumer\'s persistent ledger record (NA-1 cross-check).',
+          chain_index: i,
+          chain_value: previousHash,
+          expected_value: expectedPriorHash,
+        },
+      };
+    }
+  }
+
+  return { valid: true };
+}

--- a/src/constraints/builtins/nonce-unique-per-signer-window.ts
+++ b/src/constraints/builtins/nonce-unique-per-signer-window.ts
@@ -128,6 +128,28 @@ export function evaluateNonceUniquePerSignerWindow(
     };
   }
 
+  // F-001 mitigation (iter-2 HIGH): runtime shape validation for state.
+  // Sibling builtins (sequence-monotonic, chain-validator) validate their
+  // Map state at the trust boundary; FR-C1 must inherit the same
+  // discipline. Without this, a JSON-revived state (where the Set decoded
+  // to an Array) would throw TypeError on `seen.has(...)`. The bridge
+  // iter-2 review surfaced this as the security floor — when sibling
+  // builtins share a contract, the weakest one defines the system's
+  // actual safety floor.
+  if (state !== undefined && !(state.per_signer instanceof Map)) {
+    return {
+      valid: false,
+      diagnostic: {
+        code: 'NONCE_INVALID_INPUT',
+        message:
+          'nonce_unique_per_signer_window: state.per_signer must be a Map ' +
+          'instance. Consumer-supplied state crosses a trust boundary; the ' +
+          'library validates the runtime shape rather than relying on ' +
+          'TypeScript type erasure.',
+      },
+    };
+  }
+
   if (state === undefined) {
     return {
       valid: true,
@@ -146,6 +168,26 @@ export function evaluateNonceUniquePerSignerWindow(
   }
 
   const seen = state.per_signer.get(signerId);
+  // F-001 mitigation (iter-2 HIGH): also validate the inner bucket. The
+  // outer per_signer Map check guarantees `state.per_signer` is a Map,
+  // but `.get()` returns whatever was put in — a JSON-revived state
+  // could have the bucket as an Array, plain object, or null. Validate
+  // before invoking `.has()`.
+  if (seen !== undefined && !(seen instanceof Set)) {
+    return {
+      valid: false,
+      diagnostic: {
+        code: 'NONCE_INVALID_INPUT',
+        message:
+          'nonce_unique_per_signer_window: state.per_signer.get(...) must ' +
+          'return a Set instance (or be undefined for unknown signers). ' +
+          'Consumer-supplied state crosses a trust boundary; the library ' +
+          'validates the runtime shape rather than relying on TypeScript ' +
+          'type erasure.',
+        signer_id: signerId,
+      },
+    };
+  }
   if (seen && seen.has(nonce)) {
     return {
       valid: false,

--- a/src/constraints/builtins/nonce-unique-per-signer-window.ts
+++ b/src/constraints/builtins/nonce-unique-per-signer-window.ts
@@ -150,6 +150,27 @@ export function evaluateNonceUniquePerSignerWindow(
     };
   }
 
+  // Iter-3 LOW F-002 mitigation: validate window_seconds is a finite
+  // non-negative number. NaN, Infinity, negative values, or non-number
+  // types would surface in diagnostics and degrade troubleshooting.
+  if (
+    state !== undefined &&
+    (typeof state.window_seconds !== 'number' ||
+      !Number.isFinite(state.window_seconds) ||
+      state.window_seconds < 0)
+  ) {
+    return {
+      valid: false,
+      diagnostic: {
+        code: 'NONCE_INVALID_INPUT',
+        message:
+          'nonce_unique_per_signer_window: state.window_seconds must be a ' +
+          'finite non-negative number. NaN, Infinity, negative values, and ' +
+          'non-number types are rejected at the trust boundary.',
+      },
+    };
+  }
+
   if (state === undefined) {
     return {
       valid: true,

--- a/src/constraints/builtins/nonce-unique-per-signer-window.ts
+++ b/src/constraints/builtins/nonce-unique-per-signer-window.ts
@@ -1,0 +1,165 @@
+/**
+ * `nonce_unique_per_signer_window` constraint builtin (FR-C1, v8.6.0).
+ *
+ * State-bearing replay-detection check. For a sliding time window keyed by
+ * `signer_id`, asserts that the `(signer_id, nonce)` pair under validation
+ * has not already been observed within the window. Returns a structured
+ * diagnostic so the constraint evaluator's DSL wrapper can surface a
+ * boolean while consumers reach the underlying reason via the standalone
+ * function.
+ *
+ * **State semantics.** The check operates on per-signer `Set<nonce>`
+ * histories supplied by the consumer via the validate() `nonceWindow`
+ * option. A signer's set is the nonces emitted within
+ * `[now - window_seconds, now]`. The library does NOT manage the sliding
+ * window itself — pruning expired nonces is a consumer obligation
+ * (per ADR-010, the library declares the rule, not the storage).
+ *
+ * **Three outcomes:**
+ *   - `valid: true` (no diagnostic) when the nonce is fresh (not in the
+ *     supplied window).
+ *   - `valid: false` with code `NONCE_REPLAY_DETECTED` when the nonce is
+ *     already in the window for the same signer.
+ *   - `valid: true` with diagnostic code `NONCE_CONTEXT_DEFERRED` when
+ *     the consumer did not supply a window at all — the obligation is
+ *     deferred to consumer-side evaluation, mirroring the ORD-3
+ *     context-absent manifest-promotion pattern from PR-A2.3.
+ *
+ * Cross-runner parity: the diagnostic code strings are normative across
+ * the four language runners (TS / Go / Python / Rust). The `code` field
+ * is the comparison surface; `message` is human-readable and not pinned
+ * across runners.
+ *
+ * @see SDD section 5.5.2 — Nonce-window protocol (NORMATIVE)
+ * @see PR-A3.2 §FR-A4 — companion ORD-3 fail-closed contract pattern
+ * @since v8.6.0 — FR-C1
+ */
+
+/**
+ * Normative error codes for `nonce_unique_per_signer_window`. Stable
+ * across cross-language runners; mirrored in the
+ * `UnverifiedObligationReason` union as `'nonce_replay_detected'` and
+ * `'nonce_context_deferred'`.
+ */
+export type NonceBuiltinErrorCode =
+  | 'NONCE_REPLAY_DETECTED'
+  | 'NONCE_CONTEXT_DEFERRED'
+  | 'NONCE_INVALID_INPUT';
+
+export interface NonceBuiltinDiagnostic {
+  code: NonceBuiltinErrorCode;
+  /** Human-readable explanation; not pinned across runners. */
+  message: string;
+  /** Signer the violation applied to (when known). */
+  signer_id?: string;
+  /** Nonce value that triggered the diagnostic (when known). */
+  nonce?: string;
+}
+
+/**
+ * Per-signer nonce-window state. Each signer maps to the set of nonces
+ * observed within the configured sliding window. The library does NOT
+ * mutate this state; it is read-only at evaluate-time.
+ *
+ * Consumers populate the structure from their persistent store; the
+ * pruning of expired nonces is a consumer concern per ADR-010.
+ */
+export interface NonceWindowState {
+  /** Window length in seconds (consumer-declared; library does not enforce a default). */
+  window_seconds: number;
+  /** Nonces seen within the window, partitioned by signer. */
+  per_signer: ReadonlyMap<string, ReadonlySet<string>>;
+}
+
+export interface EvaluateNonceUniquePerSignerWindowResult {
+  valid: boolean;
+  diagnostic?: NonceBuiltinDiagnostic;
+}
+
+/**
+ * Standalone evaluator. The constraint-DSL wrapper at
+ * `src/constraints/evaluator.ts` `parseNonceUniquePerSignerWindow()`
+ * returns a boolean; direct callers wanting the structured diagnostic
+ * should use this entry point.
+ *
+ * Argument shape mirrors the other state-bearing builtins:
+ *   `nonce_unique_per_signer_window(record, signer_id_field, nonce_field, state?)`
+ *
+ * @param record - The single record under validation. Must be a non-null
+ *                 object containing `signer_id_field` and `nonce_field`
+ *                 string-typed values.
+ * @param signerIdField - Name of the field on `record` carrying the
+ *                        signer identifier.
+ * @param nonceField - Name of the field on `record` carrying the nonce
+ *                     value.
+ * @param state - The per-signer window state supplied by the consumer.
+ *                When `undefined`, the diagnostic is `NONCE_CONTEXT_DEFERRED`
+ *                and the result is `valid: true` (the obligation surfaces
+ *                via the manifest entry on the consumer side).
+ */
+export function evaluateNonceUniquePerSignerWindow(
+  record: unknown,
+  signerIdField: string,
+  nonceField: string,
+  state: NonceWindowState | undefined,
+): EvaluateNonceUniquePerSignerWindowResult {
+  if (record === null || typeof record !== 'object' || Array.isArray(record)) {
+    return {
+      valid: false,
+      diagnostic: {
+        code: 'NONCE_INVALID_INPUT',
+        message: 'nonce_unique_per_signer_window: record argument must be a non-array object',
+      },
+    };
+  }
+  const rec = record as Record<string, unknown>;
+  const signerId = rec[signerIdField];
+  const nonce = rec[nonceField];
+
+  if (typeof signerId !== 'string' || typeof nonce !== 'string') {
+    return {
+      valid: false,
+      diagnostic: {
+        code: 'NONCE_INVALID_INPUT',
+        message:
+          `nonce_unique_per_signer_window: ${signerIdField} and ${nonceField} ` +
+          'must both resolve to string values on the record',
+      },
+    };
+  }
+
+  if (state === undefined) {
+    return {
+      valid: true,
+      diagnostic: {
+        code: 'NONCE_CONTEXT_DEFERRED',
+        message:
+          `nonce_unique_per_signer_window: nonceWindow state was not supplied via ` +
+          'validate() options.nonceWindow. The obligation is deferred to consumer-side ' +
+          'evaluation; the consumer MUST maintain a per-signer set of nonces seen within ' +
+          'the [now - window_seconds, now] window and reject any record whose nonce ' +
+          'already appears in the set for its signer.',
+        signer_id: signerId,
+        nonce,
+      },
+    };
+  }
+
+  const seen = state.per_signer.get(signerId);
+  if (seen && seen.has(nonce)) {
+    return {
+      valid: false,
+      diagnostic: {
+        code: 'NONCE_REPLAY_DETECTED',
+        message:
+          `nonce_unique_per_signer_window: nonce "${nonce}" already observed for ` +
+          `signer "${signerId}" within the ${state.window_seconds}s window — ` +
+          'replay candidate. Reject the record and investigate the producer.',
+        signer_id: signerId,
+        nonce,
+      },
+    };
+  }
+
+  return { valid: true };
+}

--- a/src/constraints/builtins/sequence-monotonic-per-cluster.ts
+++ b/src/constraints/builtins/sequence-monotonic-per-cluster.ts
@@ -20,11 +20,17 @@
  *   4. **CT-08 cluster-id mismatch** (record cluster_id ≠ state
  *      cluster_id). Fires BEFORE any state-map `.get` lookup so a
  *      cross-cluster lookup cannot silently succeed.
- *   5. State-absent (deferred) branch (returns `valid: true` +
+ *   5. **CT-03 numeric-regex pre-validation** (rejects malformed
+ *      string-encoded BigInts before invoking `BigInt()`). Fires BEFORE
+ *      the state-absent branch — iter-3 MEDIUM F11 mitigation —
+ *      because deferring on malformed input is the wrong-failure-mode
+ *      trap (Postel's Law walk-back per Google AIP-210). A '007'
+ *      sequence is a data-shape error regardless of state presence;
+ *      surfacing SEQUENCE_INVALID_INPUT immediately gives operators the
+ *      actionable diagnostic.
+ *   6. State-absent (deferred) branch (returns `valid: true` +
  *      `SEQUENCE_CONTEXT_DEFERRED` diagnostic when the consumer didn't
  *      supply state).
- *   6. CT-03 numeric-regex pre-validation (rejects malformed
- *      string-encoded BigInts before invoking `BigInt()`).
  *   7. Key-version monotonicity (`KEY_VERSION_REGRESSION` if record's
  *      key_version < state's highest_key_version).
  *   8. Sequence monotonicity (`SEQUENCE_MONOTONIC_VIOLATION` if record's
@@ -199,8 +205,10 @@ export function evaluateSequenceMonotonicPerCluster(
       diagnostic: {
         code: 'SEQUENCE_INVALID_INPUT',
         message:
-          'sequence_monotonic_per_cluster: cluster_id, signer_id, sequence, and ' +
-          'key_version must all resolve to string values on the record',
+          'sequence_monotonic_per_cluster: ' +
+          `${clusterIdField}, ${signerIdField}, ${sequenceField}, and ${keyVersionField} ` +
+          'must all resolve to string values on the record (iter-3 LOW 8e36 — ' +
+          'dynamic field names mirror sibling builtins).',
       },
     };
   }
@@ -245,6 +253,28 @@ export function evaluateSequenceMonotonicPerCluster(
     };
   }
 
+  // Iter-3 MEDIUM F11 mitigation: CT-03 numeric-regex pre-validation runs
+  // BEFORE the state-absent deferral check. Rationale: deferring on
+  // malformed input is the wrong-failure-mode trap (Postel's Law walk-back
+  // per Google AIP-210 / HTTP/2 working group). A record with sequence
+  // '007' is a data-shape error regardless of whether the consumer
+  // supplied state — surfacing SEQUENCE_INVALID_INPUT immediately gives
+  // operators the actionable diagnostic; deferring would silently pass
+  // garbage upstream. The deferred branch (state-absent) covers
+  // protocol-level state obligations, not data-shape obligations.
+  if (!NUMERIC_STRING_RE.test(sequence) || !NUMERIC_STRING_RE.test(keyVersion)) {
+    return {
+      valid: false,
+      diagnostic: {
+        code: 'SEQUENCE_INVALID_INPUT',
+        message:
+          'sequence_monotonic_per_cluster: sequence and key_version MUST be ' +
+          'decimal-numeric strings with no leading zero (except "0") and no sign. ' +
+          'See CT-03 string-encoded-BigInt contract.',
+      },
+    };
+  }
+
   if (state === undefined) {
     return {
       valid: true,
@@ -258,22 +288,6 @@ export function evaluateSequenceMonotonicPerCluster(
           'that regress either counter.',
         cluster_id: clusterId,
         signer_id: signerId,
-      },
-    };
-  }
-
-  // CT-03 boundary: parse sequence + key_version as BigInt without try/catch.
-  // Pre-validate via numeric regex; reject malformed input as
-  // SEQUENCE_INVALID_INPUT.
-  if (!NUMERIC_STRING_RE.test(sequence) || !NUMERIC_STRING_RE.test(keyVersion)) {
-    return {
-      valid: false,
-      diagnostic: {
-        code: 'SEQUENCE_INVALID_INPUT',
-        message:
-          'sequence_monotonic_per_cluster: sequence and key_version MUST be ' +
-          'decimal-numeric strings with no leading zero (except "0") and no sign. ' +
-          'See CT-03 string-encoded-BigInt contract.',
       },
     };
   }

--- a/src/constraints/builtins/sequence-monotonic-per-cluster.ts
+++ b/src/constraints/builtins/sequence-monotonic-per-cluster.ts
@@ -134,9 +134,21 @@ export interface EvaluateSequenceMonotonicResult {
  * for any string content: the JSON array form preserves ordinal
  * separation via length-prefixed structure (each string is bracketed by
  * `"..."` with internal special characters escaped) and the array shape
- * itself is unambiguous. The encoding is deterministic and stable across
- * cross-language runners (TS / Go / Python / Rust JSON serializers all
- * agree on `["a","b"]` for two ASCII strings).
+ * itself is unambiguous.
+ *
+ * **Cross-runner scope clarification (iter-2 LOW F6).** The composite
+ * key is **runner-local** — it is used as a JS Map key inside this
+ * builtin and is never serialized across the wire. Cross-language
+ * runners reimplementing this check use whatever injective composite-key
+ * encoding their language idiomatically supports (Go: `[2]string`-keyed
+ * map; Python: tuple-keyed dict; Rust: `(String, String)`-keyed `HashMap`)
+ * — the contract is *injectivity within the runner*, not byte-stability
+ * across runners. If a future cycle moves composite keys onto the wire
+ * (e.g. for cross-runner state-replay vectors), the canonical
+ * serialization SHOULD be RFC 8785 JCS rather than this `JSON.stringify`
+ * call (which uses ECMAScript JSON rules — not JCS — for whitespace and
+ * Unicode handling). For v8.6.0 scope, the within-runner injectivity is
+ * sufficient.
  *
  * @see iter-1 bridge finding "Composite key uses a potentially unsafe delimiter"
  */

--- a/src/constraints/builtins/sequence-monotonic-per-cluster.ts
+++ b/src/constraints/builtins/sequence-monotonic-per-cluster.ts
@@ -6,15 +6,38 @@
  * greater than the last-observed sequence, and that the `key_version`
  * itself never regresses across the cluster's history.
  *
- * **CT-08 hardening (cluster-id mismatch precedes state lookup).** The
- * very first check this builtin performs is whether the validating
- * record's `cluster_id` matches the `cluster_id` declared on the supplied
- * state. A mismatch returns `CLUSTER_ID_MISMATCH` BEFORE any state-map
- * lookup. This prevents a class of bug where a cross-cluster lookup
- * succeeds silently — e.g., consumer calls validate() with state for
- * cluster A but the record's `cluster_id` is cluster B, and the
- * per-cluster Map happens to contain B's history under the same key. The
- * mismatch check is the load-bearing trust boundary.
+ * **Precedence ladder.** The check order inside this builtin is fixed
+ * and load-bearing — each step is a documented gate that must run before
+ * the next can be trusted:
+ *
+ *   1. Record shape validation (record is non-null, non-array object).
+ *   2. Field type validation (signer_id, sequence, key_version etc.
+ *      resolve to strings on the record).
+ *   3. State runtime-shape validation (`state.last_sequence` is a `Map`
+ *      instance; required because TypeScript type erasure can't enforce
+ *      runtime shape across consumer trust boundaries — iter-1 HIGH
+ *      F-002/F-003 mitigation).
+ *   4. **CT-08 cluster-id mismatch** (record cluster_id ≠ state
+ *      cluster_id). Fires BEFORE any state-map `.get` lookup so a
+ *      cross-cluster lookup cannot silently succeed.
+ *   5. State-absent (deferred) branch (returns `valid: true` +
+ *      `SEQUENCE_CONTEXT_DEFERRED` diagnostic when the consumer didn't
+ *      supply state).
+ *   6. CT-03 numeric-regex pre-validation (rejects malformed
+ *      string-encoded BigInts before invoking `BigInt()`).
+ *   7. Key-version monotonicity (`KEY_VERSION_REGRESSION` if record's
+ *      key_version < state's highest_key_version).
+ *   8. Sequence monotonicity (`SEQUENCE_MONOTONIC_VIOLATION` if record's
+ *      sequence ≤ last-observed sequence for the
+ *      `(signer_id, key_version)` composite key).
+ *
+ * Reordering these steps would break load-bearing invariants: shape
+ * validation gates type-safe access; runtime-shape validation gates
+ * `.get` calls; CT-08 gates the state-map lookup; CT-03 gates `BigInt()`
+ * construction. The CT-08 spy-test (`'CT-08 mismatch check fires BEFORE
+ * last_sequence Map.get is called'`) locks the cluster-id-precedes-lookup
+ * ordering structurally — moving CT-08 below the state lookup would fail
+ * the test.
  *
  * **CT-03 string→BigInt parsing.** `sequence` and `key_version` are
  * declared as string-encoded BigInt on the wire (per the cycle-005 RC2
@@ -97,11 +120,28 @@ export interface EvaluateSequenceMonotonicResult {
 
 /**
  * Compose the `(signer_id, key_version)` key used for the per-cluster
- * `last_sequence` map. Keeping this as a single concatenation function
- * makes the cross-runner contract explicit: the format is stable.
+ * `last_sequence` map.
+ *
+ * Uses **`JSON.stringify` injective serialization** rather than a delimiter
+ * character. A naive delimiter (e.g. `${signerId}|${keyVersion}`) is
+ * forgeable when either component admits the delimiter character — e.g.
+ * `('a|b', 'c')` and `('a', 'b|c')` would collide on `"a|b|c"`, producing
+ * a cross-signer state-collision in a security-relevant map. Iter-1
+ * bridge consensus (HIGH F-CVE-class) flagged this as the same bug class
+ * behind CVE-2020-1971 (OpenSSL) and SAML signature-wrapping attacks.
+ *
+ * `JSON.stringify([signerId, keyVersion])` produces an injective encoding
+ * for any string content: the JSON array form preserves ordinal
+ * separation via length-prefixed structure (each string is bracketed by
+ * `"..."` with internal special characters escaped) and the array shape
+ * itself is unambiguous. The encoding is deterministic and stable across
+ * cross-language runners (TS / Go / Python / Rust JSON serializers all
+ * agree on `["a","b"]` for two ASCII strings).
+ *
+ * @see iter-1 bridge finding "Composite key uses a potentially unsafe delimiter"
  */
 export function composeSequenceKey(signerId: string, keyVersion: string): string {
-  return `${signerId}|${keyVersion}`;
+  return JSON.stringify([signerId, keyVersion]);
 }
 
 /**
@@ -149,6 +189,27 @@ export function evaluateSequenceMonotonicPerCluster(
         message:
           'sequence_monotonic_per_cluster: cluster_id, signer_id, sequence, and ' +
           'key_version must all resolve to string values on the record',
+      },
+    };
+  }
+
+  // F-002/F-003 mitigation (iter-1 HIGH): runtime shape validation for
+  // state. TypeScript's structural type "ReadonlyMap" evaporates at runtime;
+  // a consumer passing a plain object, a deserialized JSON shape, or null
+  // would invoke `.get` on a non-Map and throw an uncaught TypeError at a
+  // security boundary. Validate the shape explicitly before any field
+  // access, returning the structured SEQUENCE_INVALID_INPUT diagnostic on
+  // mismatch.
+  if (state !== undefined && !(state.last_sequence instanceof Map)) {
+    return {
+      valid: false,
+      diagnostic: {
+        code: 'SEQUENCE_INVALID_INPUT',
+        message:
+          'sequence_monotonic_per_cluster: state.last_sequence must be a Map ' +
+          'instance. Consumer-supplied state crosses a trust boundary; the ' +
+          'library validates the runtime shape rather than relying on ' +
+          'TypeScript type erasure.',
       },
     };
   }

--- a/src/constraints/builtins/sequence-monotonic-per-cluster.ts
+++ b/src/constraints/builtins/sequence-monotonic-per-cluster.ts
@@ -1,0 +1,279 @@
+/**
+ * `sequence_monotonic_per_cluster` constraint builtin (FR-C2, v8.6.0).
+ *
+ * State-bearing per-cluster monotonicity check. Asserts that for a given
+ * cluster and key-version, the validating record's `sequence` is strictly
+ * greater than the last-observed sequence, and that the `key_version`
+ * itself never regresses across the cluster's history.
+ *
+ * **CT-08 hardening (cluster-id mismatch precedes state lookup).** The
+ * very first check this builtin performs is whether the validating
+ * record's `cluster_id` matches the `cluster_id` declared on the supplied
+ * state. A mismatch returns `CLUSTER_ID_MISMATCH` BEFORE any state-map
+ * lookup. This prevents a class of bug where a cross-cluster lookup
+ * succeeds silently — e.g., consumer calls validate() with state for
+ * cluster A but the record's `cluster_id` is cluster B, and the
+ * per-cluster Map happens to contain B's history under the same key. The
+ * mismatch check is the load-bearing trust boundary.
+ *
+ * **CT-03 string→BigInt parsing.** `sequence` and `key_version` are
+ * declared as string-encoded BigInt on the wire (per the cycle-005 RC2
+ * patch covering arbitrarily-large coordinator counters). Comparison
+ * happens at the BigInt boundary using a deterministic parser that
+ * rejects non-numeric strings with `SEQUENCE_INVALID_INPUT` rather than
+ * throwing — `BigInt()` throws on malformed input which would surface as
+ * an uncaught exception inside the evaluator. The parser-without-throw
+ * pattern follows the sprint-A3.3 AC clause "no try/catch" by
+ * pre-validating the string against a numeric regex before invoking
+ * `BigInt()`.
+ *
+ * **NA-1 expected_prior_hash usage.** This builtin does NOT consume the
+ * `expected_prior_hash` field — that's FR-C3 territory. NA-1 only
+ * applies to `chain_validator_prev_hash`.
+ *
+ * **Three failure modes:**
+ *   - `CLUSTER_ID_MISMATCH` — record's cluster_id ≠ state's cluster_id
+ *     (CT-08 precedence).
+ *   - `KEY_VERSION_REGRESSION` — record's key_version < last-observed
+ *     key_version for this cluster.
+ *   - `SEQUENCE_MONOTONIC_VIOLATION` — record's sequence ≤ last-observed
+ *     sequence for this `(cluster_id, signer_id, key_version)` triple.
+ *
+ * **One deferred mode:**
+ *   - `SEQUENCE_CONTEXT_DEFERRED` — state not supplied; obligation
+ *     deferred to consumer.
+ *
+ * @see SDD section 5.5.3 — Per-cluster sequence monotonicity (NORMATIVE)
+ * @see PR-A3.2 §FR-A3 — companion vocabulary-drift dispatch pattern
+ * @since v8.6.0 — FR-C2 (with CT-08 + CT-03)
+ */
+
+/**
+ * Numeric-string regex (decimal, no sign, no leading zero except for "0"
+ * itself). Pre-validates string-encoded BigInts so `BigInt()` doesn't
+ * throw on malformed input — keeps the evaluator's no-try/catch
+ * invariant.
+ */
+const NUMERIC_STRING_RE = /^(0|[1-9][0-9]*)$/;
+
+export type SequenceBuiltinErrorCode =
+  | 'CLUSTER_ID_MISMATCH'
+  | 'KEY_VERSION_REGRESSION'
+  | 'SEQUENCE_MONOTONIC_VIOLATION'
+  | 'SEQUENCE_CONTEXT_DEFERRED'
+  | 'SEQUENCE_INVALID_INPUT';
+
+export interface SequenceBuiltinDiagnostic {
+  code: SequenceBuiltinErrorCode;
+  message: string;
+  /** The cluster_id the violation applied to (when relevant). */
+  cluster_id?: string;
+  /** The signer_id the violation applied to (when relevant). */
+  signer_id?: string;
+  /** Last-observed value (sequence or key_version) on the violation path. */
+  last_observed?: string;
+  /** Asserted value (sequence or key_version) on the violation path. */
+  asserted?: string;
+}
+
+/**
+ * Per-cluster sequence-monotonicity state. Each cluster's history is keyed
+ * by `(signer_id, key_version)` so a key-rotation overlap window does not
+ * regress the sequence counter.
+ */
+export interface SequenceClusterState {
+  /** Cluster identifier this state applies to. CT-08 mismatch check uses this. */
+  cluster_id: string;
+  /** Highest key_version ever observed for this cluster. Set even on key rotation. */
+  highest_key_version: string;
+  /** Per-(signer_id, key_version) last-observed sequence values. */
+  last_sequence: ReadonlyMap<string, string>;
+}
+
+export interface EvaluateSequenceMonotonicResult {
+  valid: boolean;
+  diagnostic?: SequenceBuiltinDiagnostic;
+}
+
+/**
+ * Compose the `(signer_id, key_version)` key used for the per-cluster
+ * `last_sequence` map. Keeping this as a single concatenation function
+ * makes the cross-runner contract explicit: the format is stable.
+ */
+export function composeSequenceKey(signerId: string, keyVersion: string): string {
+  return `${signerId}|${keyVersion}`;
+}
+
+/**
+ * Standalone evaluator. The constraint-DSL wrapper at
+ * `src/constraints/evaluator.ts` `parseSequenceMonotonicPerCluster()`
+ * returns a boolean; direct callers wanting the structured diagnostic
+ * should use this entry point.
+ *
+ * Argument shape:
+ *   `sequence_monotonic_per_cluster(record, cluster_id_field, signer_id_field, sequence_field, key_version_field, state?)`
+ */
+export function evaluateSequenceMonotonicPerCluster(
+  record: unknown,
+  clusterIdField: string,
+  signerIdField: string,
+  sequenceField: string,
+  keyVersionField: string,
+  state: SequenceClusterState | undefined,
+): EvaluateSequenceMonotonicResult {
+  if (record === null || typeof record !== 'object' || Array.isArray(record)) {
+    return {
+      valid: false,
+      diagnostic: {
+        code: 'SEQUENCE_INVALID_INPUT',
+        message: 'sequence_monotonic_per_cluster: record argument must be a non-array object',
+      },
+    };
+  }
+  const rec = record as Record<string, unknown>;
+  const clusterId = rec[clusterIdField];
+  const signerId = rec[signerIdField];
+  const sequence = rec[sequenceField];
+  const keyVersion = rec[keyVersionField];
+
+  if (
+    typeof clusterId !== 'string' ||
+    typeof signerId !== 'string' ||
+    typeof sequence !== 'string' ||
+    typeof keyVersion !== 'string'
+  ) {
+    return {
+      valid: false,
+      diagnostic: {
+        code: 'SEQUENCE_INVALID_INPUT',
+        message:
+          'sequence_monotonic_per_cluster: cluster_id, signer_id, sequence, and ' +
+          'key_version must all resolve to string values on the record',
+      },
+    };
+  }
+
+  // CT-08: cluster-id mismatch FIRST, before any state lookup. The mismatch
+  // check is the load-bearing trust boundary — a state lookup that crosses
+  // clusters could silently succeed because the per-cluster Map happens to
+  // contain the other cluster's history under the same composite key.
+  if (state !== undefined && state.cluster_id !== clusterId) {
+    return {
+      valid: false,
+      diagnostic: {
+        code: 'CLUSTER_ID_MISMATCH',
+        message:
+          `sequence_monotonic_per_cluster: record cluster_id "${clusterId}" does not ` +
+          `match state cluster_id "${state.cluster_id}". The state lookup MUST NOT ` +
+          'cross clusters — fix the consumer call site to dispatch to the correct ' +
+          'cluster\'s state, or treat this as a misrouted record.',
+        cluster_id: clusterId,
+      },
+    };
+  }
+
+  if (state === undefined) {
+    return {
+      valid: true,
+      diagnostic: {
+        code: 'SEQUENCE_CONTEXT_DEFERRED',
+        message:
+          'sequence_monotonic_per_cluster: per-cluster sequence state was not ' +
+          'supplied via validate() options.sequenceState. The obligation is ' +
+          'deferred to consumer-side evaluation; the consumer MUST maintain ' +
+          'highest_key_version + last_sequence per cluster and reject records ' +
+          'that regress either counter.',
+        cluster_id: clusterId,
+        signer_id: signerId,
+      },
+    };
+  }
+
+  // CT-03 boundary: parse sequence + key_version as BigInt without try/catch.
+  // Pre-validate via numeric regex; reject malformed input as
+  // SEQUENCE_INVALID_INPUT.
+  if (!NUMERIC_STRING_RE.test(sequence) || !NUMERIC_STRING_RE.test(keyVersion)) {
+    return {
+      valid: false,
+      diagnostic: {
+        code: 'SEQUENCE_INVALID_INPUT',
+        message:
+          'sequence_monotonic_per_cluster: sequence and key_version MUST be ' +
+          'decimal-numeric strings with no leading zero (except "0") and no sign. ' +
+          'See CT-03 string-encoded-BigInt contract.',
+      },
+    };
+  }
+  if (!NUMERIC_STRING_RE.test(state.highest_key_version)) {
+    return {
+      valid: false,
+      diagnostic: {
+        code: 'SEQUENCE_INVALID_INPUT',
+        message:
+          'sequence_monotonic_per_cluster: state.highest_key_version is malformed ' +
+          '(must match the same CT-03 numeric-string contract).',
+      },
+    };
+  }
+
+  const recordKeyVersion = BigInt(keyVersion);
+  const stateHighestKeyVersion = BigInt(state.highest_key_version);
+
+  // Key-version monotonicity: record's key_version may equal or exceed the
+  // highest-observed key_version, but it MUST NOT regress.
+  if (recordKeyVersion < stateHighestKeyVersion) {
+    return {
+      valid: false,
+      diagnostic: {
+        code: 'KEY_VERSION_REGRESSION',
+        message:
+          `sequence_monotonic_per_cluster: record key_version "${keyVersion}" is ` +
+          `less than the highest-observed key_version "${state.highest_key_version}" ` +
+          'for this cluster. Key rotation is monotonic; a regression indicates ' +
+          'replay or producer misconfiguration.',
+        cluster_id: clusterId,
+        signer_id: signerId,
+        last_observed: state.highest_key_version,
+        asserted: keyVersion,
+      },
+    };
+  }
+
+  // Sequence monotonicity within (signer_id, key_version) window.
+  const compositeKey = composeSequenceKey(signerId, keyVersion);
+  const lastSequenceStr = state.last_sequence.get(compositeKey);
+  if (lastSequenceStr !== undefined) {
+    if (!NUMERIC_STRING_RE.test(lastSequenceStr)) {
+      return {
+        valid: false,
+        diagnostic: {
+          code: 'SEQUENCE_INVALID_INPUT',
+          message:
+            `sequence_monotonic_per_cluster: state last_sequence value for ` +
+            `"${compositeKey}" is malformed.`,
+        },
+      };
+    }
+    const recordSequence = BigInt(sequence);
+    const lastSequence = BigInt(lastSequenceStr);
+    if (recordSequence <= lastSequence) {
+      return {
+        valid: false,
+        diagnostic: {
+          code: 'SEQUENCE_MONOTONIC_VIOLATION',
+          message:
+            `sequence_monotonic_per_cluster: record sequence "${sequence}" is ` +
+            `not strictly greater than last-observed "${lastSequenceStr}" for ` +
+            `(signer "${signerId}", key_version "${keyVersion}"). Sequence ` +
+            'must increase strictly per (signer, key_version) tuple.',
+          cluster_id: clusterId,
+          signer_id: signerId,
+          last_observed: lastSequenceStr,
+          asserted: sequence,
+        },
+      };
+    }
+  }
+
+  return { valid: true };
+}

--- a/src/constraints/evaluator-spec.ts
+++ b/src/constraints/evaluator-spec.ts
@@ -1548,4 +1548,115 @@ export const EVALUATOR_BUILTIN_SPECS: ReadonlyMap<EvaluatorBuiltin, EvaluatorBui
       'extract_path is dot-only — bracket-syntax `[N]` returns undefined and is treated as no-ref',
     ],
   }],
+
+  // State-bearing protocol builtins (v8.6.0, PR-A3.3 — FR-C1/C2/C3)
+  ['nonce_unique_per_signer_window', {
+    name: 'nonce_unique_per_signer_window',
+    signature: 'nonce_unique_per_signer_window(record, signer_id_field, nonce_field) → boolean',
+    description:
+      'State-bearing replay-detection check. Returns true when the (signer_id, nonce) pair on the record has not been observed within the per-signer sliding window supplied via EvaluationContext.nonce_window. When the window is unset, the standalone evaluator returns NONCE_CONTEXT_DEFERRED and the DSL wrapper passes (true) — consumers wanting the diagnostic surface should call the standalone evaluateNonceUniquePerSignerWindow().',
+    arguments: [
+      { name: 'record', type: 'object', description: 'The single record under validation. Must contain string-typed signer_id_field and nonce_field values.' },
+      { name: 'signer_id_field', type: 'string', description: 'Field name on the record carrying the signer identifier.' },
+      { name: 'nonce_field', type: 'string', description: 'Field name on the record carrying the nonce value.' },
+    ],
+    return_type: 'boolean',
+    short_circuit: true,
+    examples: [
+      {
+        description: 'No nonce_window state supplied → defers to consumer (returns true)',
+        context: { record: { signer_id: 'agent-a', nonce: 'n1' } },
+        expression: "nonce_unique_per_signer_window(record, 'signer_id', 'nonce')",
+        expected: true,
+      },
+      {
+        description: 'Non-object record returns false (NONCE_INVALID_INPUT diagnostic)',
+        context: { record: null },
+        expression: "nonce_unique_per_signer_window(record, 'signer_id', 'nonce')",
+        expected: false,
+      },
+    ],
+    edge_cases: [
+      'Non-object record returns false (NONCE_INVALID_INPUT)',
+      'Missing signer_id_field or nonce_field returns false (NONCE_INVALID_INPUT)',
+      'nonce_window state absent returns true with NONCE_CONTEXT_DEFERRED diagnostic (consumer-deferred)',
+      'Nonce found in signer\'s set returns false (NONCE_REPLAY_DETECTED)',
+      'Signer not in per_signer map → fresh nonce, returns true',
+    ],
+  }],
+
+  ['sequence_monotonic_per_cluster', {
+    name: 'sequence_monotonic_per_cluster',
+    signature:
+      'sequence_monotonic_per_cluster(record, cluster_id_field, signer_id_field, sequence_field, key_version_field) → boolean',
+    description:
+      'State-bearing per-cluster sequence + key-version monotonicity check. CT-08 cluster-id mismatch fires BEFORE any state lookup; CT-03 string→BigInt parsing uses a numeric-regex pre-validator so BigInt() never throws. Reads sequence_state from EvaluationContext.',
+    arguments: [
+      { name: 'record', type: 'object', description: 'The single record under validation.' },
+      { name: 'cluster_id_field', type: 'string', description: 'Field name carrying the cluster identifier.' },
+      { name: 'signer_id_field', type: 'string', description: 'Field name carrying the signer identifier.' },
+      { name: 'sequence_field', type: 'string', description: 'Field name carrying the string-encoded BigInt sequence number.' },
+      { name: 'key_version_field', type: 'string', description: 'Field name carrying the string-encoded BigInt key version.' },
+    ],
+    return_type: 'boolean',
+    short_circuit: true,
+    examples: [
+      {
+        description: 'No sequence_state supplied → defers to consumer (returns true)',
+        context: { record: { cluster_id: 'c1', signer_id: 's1', sequence: '1', key_version: '0' } },
+        expression: "sequence_monotonic_per_cluster(record, 'cluster_id', 'signer_id', 'sequence', 'key_version')",
+        expected: true,
+      },
+      {
+        description: 'CT-03: malformed sequence (leading zero) returns false (SEQUENCE_INVALID_INPUT)',
+        context: { record: { cluster_id: 'c1', signer_id: 's1', sequence: '007', key_version: '0' } },
+        expression: "sequence_monotonic_per_cluster(record, 'cluster_id', 'signer_id', 'sequence', 'key_version')",
+        expected: true,
+      },
+    ],
+    edge_cases: [
+      'CT-08: cluster_id mismatch returns false (CLUSTER_ID_MISMATCH) — fires BEFORE state lookup',
+      'CT-03: malformed sequence/key_version (non-numeric, leading zero, sign) returns false (SEQUENCE_INVALID_INPUT)',
+      'Key-version regression returns false (KEY_VERSION_REGRESSION)',
+      'Sequence ≤ last-observed for (signer, key_version) returns false (SEQUENCE_MONOTONIC_VIOLATION)',
+      'Key-rotation overlap: same sequence under newer key_version is allowed (separate composite key)',
+    ],
+  }],
+
+  ['chain_validator_prev_hash', {
+    name: 'chain_validator_prev_hash',
+    signature:
+      'chain_validator_prev_hash(chain, entry_hash_field, previous_hash_field) → boolean',
+    description:
+      'Ledger-style chain validity check. Asserts (1) each record\'s previous_hash equals its predecessor\'s entry_hash, (2) the chain anchors at the configured genesis sentinel, and (3) NA-1: the audit-ledger\'s expected_prior_hash matches the chain\'s on-payload value per index. Distinct from ORD-3 is_valid_dag (which validates the delegation DAG, not a linear ledger chain). Reads chain_ledger from EvaluationContext.',
+    arguments: [
+      { name: 'chain', type: 'unknown[]', description: 'Array of cluster-event records ordered from genesis-rooted to most-recent.' },
+      { name: 'entry_hash_field', type: 'string', description: 'Field name on each record carrying that record\'s own hash.' },
+      { name: 'previous_hash_field', type: 'string', description: 'Field name carrying the hash of the predecessor (or genesis sentinel for index 0).' },
+    ],
+    return_type: 'boolean',
+    short_circuit: true,
+    examples: [
+      {
+        description: 'No chain_ledger state supplied → defers to consumer (returns true)',
+        context: { chain: [{ entry_hash: 'h1', previous_hash: 'genesis:cluster-ledger' }] },
+        expression: "chain_validator_prev_hash(chain, 'entry_hash', 'previous_hash')",
+        expected: true,
+      },
+      {
+        description: 'Empty chain returns true (vacuous)',
+        context: { chain: [] },
+        expression: "chain_validator_prev_hash(chain, 'entry_hash', 'previous_hash')",
+        expected: true,
+      },
+    ],
+    edge_cases: [
+      'Empty chain returns true (vacuous)',
+      'First record\'s previous_hash != genesis sentinel returns false (CHAIN_GENESIS_VIOLATION)',
+      'Successor\'s previous_hash != predecessor\'s entry_hash returns false (CHAIN_PREV_HASH_MISMATCH)',
+      'NA-1: audit-ledger expected_prior_hash[i] != chain[i].previous_hash returns false (CHAIN_LEDGER_MISMATCH)',
+      'Audit-ledger has no entry for index i → no NA-1 cross-check fires (consumer hasn\'t recorded yet)',
+      'Custom genesis_hash via state.genesis_hash overrides the default sentinel',
+    ],
+  }],
 ]);

--- a/src/constraints/evaluator-spec.ts
+++ b/src/constraints/evaluator-spec.ts
@@ -1608,23 +1608,24 @@ export const EVALUATOR_BUILTIN_SPECS: ReadonlyMap<EvaluatorBuiltin, EvaluatorBui
         expected: true,
       },
       {
-        // Iter-1 HIGH F1 fix: this example previously expected `true` because
-        // no state was supplied (CT-03 never fires on the deferred path).
-        // The pairing was misleading — readers would infer "007" is accepted
-        // when in fact the implementation rejects it. The fixed example
-        // demonstrates the deferred-state semantics explicitly: with no
-        // state supplied, ALL records pass regardless of CT-03 violations,
-        // because the obligation is consumer-deferred. The third example
-        // (below) demonstrates the state-present path where CT-03 actually
-        // fires (iter-2 LOW F10 mitigation: deferred-vs-present-state
-        // contrast is now explicit across two paired examples).
+        // Iter-3 MEDIUM F11 mitigation: CT-03 numeric-regex pre-validation
+        // fires BEFORE the state-absent deferral check (Postel's Law
+        // walk-back). Malformed '007' is a data-shape error regardless of
+        // state presence — surfaces SEQUENCE_INVALID_INPUT immediately
+        // rather than deferring on garbage. This example demonstrates
+        // the new ordering: '007' record + no state → standalone
+        // evaluator returns SEQUENCE_INVALID_INPUT, DSL wrapper returns
+        // false. Iter-2 LOW F10 had a related concern about the previous
+        // misleading example pairing — both are resolved by the iter-3
+        // reorder (the deferred-on-garbage case no longer exists).
         description:
-          'No state supplied → defers regardless of malformed sequence ("007"). ' +
-          'CT-03 only fires when state is present; the deferred path is ' +
-          'consumer-deferred per ADR-010 and the constraint passes.',
+          'CT-03 fires before state-absent deferral (iter-3 F11 reorder): ' +
+          'malformed sequence "007" returns SEQUENCE_INVALID_INPUT ' +
+          'regardless of state presence — data-shape errors are not ' +
+          'deferrable per Postel\'s Law walk-back.',
         context: { record: { cluster_id: 'c1', signer_id: 's1', sequence: '007', key_version: '0' } },
         expression: "sequence_monotonic_per_cluster(record, 'cluster_id', 'signer_id', 'sequence', 'key_version')",
-        expected: true,
+        expected: false,
       },
     ],
     edge_cases: [

--- a/src/constraints/evaluator-spec.ts
+++ b/src/constraints/evaluator-spec.ts
@@ -1608,7 +1608,18 @@ export const EVALUATOR_BUILTIN_SPECS: ReadonlyMap<EvaluatorBuiltin, EvaluatorBui
         expected: true,
       },
       {
-        description: 'CT-03: malformed sequence (leading zero) returns false (SEQUENCE_INVALID_INPUT)',
+        // Iter-1 HIGH F1 fix: this example previously expected `true` because
+        // no state was supplied (CT-03 never fires on the deferred path).
+        // The pairing was misleading — readers would infer "007" is accepted
+        // when in fact the implementation rejects it. The fixed example
+        // demonstrates the deferred-state semantics explicitly: with no
+        // state supplied, ALL records pass regardless of CT-03 violations,
+        // because the obligation is consumer-deferred. Consumers wanting
+        // the SEQUENCE_INVALID_INPUT diagnostic must supply state.
+        description:
+          'No state supplied → defers regardless of malformed sequence ("007"). ' +
+          'CT-03 only fires when state is present; the deferred path is ' +
+          'consumer-deferred per ADR-010 and the constraint passes.',
         context: { record: { cluster_id: 'c1', signer_id: 's1', sequence: '007', key_version: '0' } },
         expression: "sequence_monotonic_per_cluster(record, 'cluster_id', 'signer_id', 'sequence', 'key_version')",
         expected: true,

--- a/src/constraints/evaluator-spec.ts
+++ b/src/constraints/evaluator-spec.ts
@@ -1614,8 +1614,10 @@ export const EVALUATOR_BUILTIN_SPECS: ReadonlyMap<EvaluatorBuiltin, EvaluatorBui
         // when in fact the implementation rejects it. The fixed example
         // demonstrates the deferred-state semantics explicitly: with no
         // state supplied, ALL records pass regardless of CT-03 violations,
-        // because the obligation is consumer-deferred. Consumers wanting
-        // the SEQUENCE_INVALID_INPUT diagnostic must supply state.
+        // because the obligation is consumer-deferred. The third example
+        // (below) demonstrates the state-present path where CT-03 actually
+        // fires (iter-2 LOW F10 mitigation: deferred-vs-present-state
+        // contrast is now explicit across two paired examples).
         description:
           'No state supplied → defers regardless of malformed sequence ("007"). ' +
           'CT-03 only fires when state is present; the deferred path is ' +
@@ -1627,10 +1629,11 @@ export const EVALUATOR_BUILTIN_SPECS: ReadonlyMap<EvaluatorBuiltin, EvaluatorBui
     ],
     edge_cases: [
       'CT-08: cluster_id mismatch returns false (CLUSTER_ID_MISMATCH) — fires BEFORE state lookup',
-      'CT-03: malformed sequence/key_version (non-numeric, leading zero, sign) returns false (SEQUENCE_INVALID_INPUT)',
+      'CT-03: malformed sequence/key_version (non-numeric, leading zero, sign) returns false (SEQUENCE_INVALID_INPUT) ONLY when state is present; without state the deferred path returns true with SEQUENCE_CONTEXT_DEFERRED diagnostic',
       'Key-version regression returns false (KEY_VERSION_REGRESSION)',
       'Sequence ≤ last-observed for (signer, key_version) returns false (SEQUENCE_MONOTONIC_VIOLATION)',
       'Key-rotation overlap: same sequence under newer key_version is allowed (separate composite key)',
+      'Iter-2 F10 contrast: examples in this spec entry exercise only the deferred path (no sequence_state) because EVALUATOR_BUILTIN_SPECS examples are executed by the test runner without an EvaluationContext; the state-present path is exercised by tests in tests/constraints/sequence-monotonic-per-cluster.test.ts',
     ],
   }],
 

--- a/src/constraints/evaluator.ts
+++ b/src/constraints/evaluator.ts
@@ -933,9 +933,24 @@ class Parser {
    * caller via `evaluateConstraint(data, expr, { nonce_window: ... })`).
    * When state is absent, the standalone evaluator returns `{ valid: true,
    * diagnostic: 'NONCE_CONTEXT_DEFERRED' }` — the DSL wrapper here returns
-   * `true` so the constraint passes; consumers wanting the diagnostic
-   * surface should use the standalone evaluator at
-   * `src/constraints/builtins/nonce-unique-per-signer-window.ts`.
+   * `true` so the constraint passes.
+   *
+   * **DSL-vs-standalone diagnostic-loss contract (iter-1 MEDIUM F3).**
+   * The constraint-DSL surface is intentionally boolean-only; the parser
+   * methods discard the structured diagnostic returned by the standalone
+   * evaluator. This is by design — the constraint-DSL is the cross-runner
+   * conformance surface and must produce identical boolean output across
+   * TS / Go / Python / Rust. Threading structured diagnostics through the
+   * DSL would (a) widen the cross-runner contract beyond what's currently
+   * specified, and (b) couple every cross-language runner author to the
+   * exact diagnostic-code taxonomy (which evolves separately from the DSL
+   * grammar). **Operators investigating a DSL-driven failure MUST call
+   * the standalone `evaluateNonceUniquePerSignerWindow` (or the sibling
+   * evaluator for sequence/chain) to get the actionable code.** The
+   * eventual diagnostic-bus design (where the parser threads diagnostics
+   * via an `EvaluationContext.diagnostics` sink) is a v8.7.0+ candidate;
+   * scoping it into FR-C1 would couple the runtime layer to the cross-
+   * runner contract without precedent.
    *
    * @since v8.6.0 — FR-C1 (PR-A3.3)
    */

--- a/src/constraints/evaluator.ts
+++ b/src/constraints/evaluator.ts
@@ -24,6 +24,9 @@
 
 import { tokenize, type Token } from './tokenizer.js';
 import { evaluateIsValidDag } from './is-valid-dag.js';
+import { evaluateNonceUniquePerSignerWindow } from './builtins/nonce-unique-per-signer-window.js';
+import { evaluateSequenceMonotonicPerCluster } from './builtins/sequence-monotonic-per-cluster.js';
+import { evaluateChainValidatorPrevHash } from './builtins/chain-validator-prev-hash.js';
 
 export const MAX_EXPRESSION_DEPTH = 32;
 
@@ -47,6 +50,31 @@ export interface EvaluationContext {
    * @since v8.3.0 — FR-6 Conditional Constraints
    */
   feature_flags?: Record<string, boolean>;
+  /**
+   * Per-signer nonce-window state for the FR-C1
+   * `nonce_unique_per_signer_window` builtin. When supplied, the builtin
+   * cross-checks the validating record's nonce against the signer's
+   * historical set; when unset, the builtin defers to consumer-side
+   * evaluation via the `NONCE_CONTEXT_DEFERRED` diagnostic.
+   * @since v8.6.0 — FR-C1 (PR-A3.3)
+   */
+  nonce_window?: import('./builtins/nonce-unique-per-signer-window.js').NonceWindowState;
+  /**
+   * Per-cluster sequence-monotonicity state for the FR-C2
+   * `sequence_monotonic_per_cluster` builtin. CT-08 cluster-id mismatch
+   * fires BEFORE any state-map lookup so cross-cluster lookups cannot
+   * succeed silently.
+   * @since v8.6.0 — FR-C2 (PR-A3.3)
+   */
+  sequence_state?: import('./builtins/sequence-monotonic-per-cluster.js').SequenceClusterState;
+  /**
+   * Audit-ledger expected-prior-hash state for the FR-C3
+   * `chain_validator_prev_hash` builtin. NA-1 cross-checks the chain's
+   * on-payload `previous_hash` against the consumer's persistent ledger
+   * expectation per chain index.
+   * @since v8.6.0 — FR-C3 (PR-A3.3)
+   */
+  chain_ledger?: import('./builtins/chain-validator-prev-hash.js').ChainLedgerState;
 }
 
 /**
@@ -198,6 +226,11 @@ class Parser {
 
       // Audit trail chain validation (v8.0.0 — Commons Protocol)
       ['audit_trail_chain_valid', () => this.parseAuditTrailChainValid()],
+
+      // State-bearing protocol builtins (v8.6.0, PR-A3.3 — FR-C1/C2/C3)
+      ['nonce_unique_per_signer_window', () => this.parseNonceUniquePerSignerWindow()],
+      ['sequence_monotonic_per_cluster', () => this.parseSequenceMonotonicPerCluster()],
+      ['chain_validator_prev_hash', () => this.parseChainValidatorPrevHash()],
     ]);
   }
 
@@ -890,6 +923,116 @@ class Parser {
     if (typeof idField !== 'string') return false;
 
     const result = evaluateIsValidDag(items, idField, refFields);
+    return result.valid;
+  }
+
+  /**
+   * Parse `nonce_unique_per_signer_window(record, signer_id_field, nonce_field)`.
+   *
+   * Reads `nonce_window` state from the EvaluationContext (supplied by the
+   * caller via `evaluateConstraint(data, expr, { nonce_window: ... })`).
+   * When state is absent, the standalone evaluator returns `{ valid: true,
+   * diagnostic: 'NONCE_CONTEXT_DEFERRED' }` — the DSL wrapper here returns
+   * `true` so the constraint passes; consumers wanting the diagnostic
+   * surface should use the standalone evaluator at
+   * `src/constraints/builtins/nonce-unique-per-signer-window.ts`.
+   *
+   * @since v8.6.0 — FR-C1 (PR-A3.3)
+   */
+  private parseNonceUniquePerSignerWindow(): boolean {
+    this.advance(); // consume 'nonce_unique_per_signer_window'
+    this.expect('paren', '(');
+    const record = this.parseExpr();
+    this.expect('comma');
+    const signerIdField = this.parseExpr();
+    this.expect('comma');
+    const nonceField = this.parseExpr();
+    this.expect('paren', ')');
+
+    if (typeof signerIdField !== 'string' || typeof nonceField !== 'string') return false;
+
+    const result = evaluateNonceUniquePerSignerWindow(
+      record,
+      signerIdField,
+      nonceField,
+      this.context?.nonce_window,
+    );
+    return result.valid;
+  }
+
+  /**
+   * Parse `sequence_monotonic_per_cluster(record, cluster_id_field,
+   * signer_id_field, sequence_field, key_version_field)`.
+   *
+   * Reads `sequence_state` from the EvaluationContext. CT-08 cluster-id
+   * mismatch fires BEFORE any state lookup; CT-03 string→BigInt parsing
+   * uses a numeric-regex pre-validator so `BigInt()` never throws.
+   *
+   * @since v8.6.0 — FR-C2 (PR-A3.3, with CT-08 + CT-03)
+   */
+  private parseSequenceMonotonicPerCluster(): boolean {
+    this.advance(); // consume 'sequence_monotonic_per_cluster'
+    this.expect('paren', '(');
+    const record = this.parseExpr();
+    this.expect('comma');
+    const clusterIdField = this.parseExpr();
+    this.expect('comma');
+    const signerIdField = this.parseExpr();
+    this.expect('comma');
+    const sequenceField = this.parseExpr();
+    this.expect('comma');
+    const keyVersionField = this.parseExpr();
+    this.expect('paren', ')');
+
+    if (
+      typeof clusterIdField !== 'string' ||
+      typeof signerIdField !== 'string' ||
+      typeof sequenceField !== 'string' ||
+      typeof keyVersionField !== 'string'
+    ) {
+      return false;
+    }
+
+    const result = evaluateSequenceMonotonicPerCluster(
+      record,
+      clusterIdField,
+      signerIdField,
+      sequenceField,
+      keyVersionField,
+      this.context?.sequence_state,
+    );
+    return result.valid;
+  }
+
+  /**
+   * Parse `chain_validator_prev_hash(chain, entry_hash_field, previous_hash_field)`.
+   *
+   * Reads `chain_ledger` audit-state from the EvaluationContext. NA-1 fix
+   * cross-checks chain's on-payload `previous_hash` against the consumer's
+   * persistent expected_prior_hash per index.
+   *
+   * @since v8.6.0 — FR-C3 (PR-A3.3, with NA-1)
+   */
+  private parseChainValidatorPrevHash(): boolean {
+    this.advance(); // consume 'chain_validator_prev_hash'
+    this.expect('paren', '(');
+    const chain = this.parseExpr();
+    this.expect('comma');
+    const entryHashField = this.parseExpr();
+    this.expect('comma');
+    const previousHashField = this.parseExpr();
+    this.expect('paren', ')');
+
+    if (typeof entryHashField !== 'string' || typeof previousHashField !== 'string') {
+      return false;
+    }
+
+    const result = evaluateChainValidatorPrevHash(
+      chain,
+      entryHashField,
+      previousHashField,
+      this.context?.chain_ledger,
+    );
     return result.valid;
   }
 
@@ -1891,6 +2034,10 @@ export const EVALUATOR_BUILTINS = [
   'audit_trail_chain_valid',
   // DAG validation (v8.4.0, FR-C1)
   'is_valid_dag',
+  // State-bearing protocol builtins (v8.6.0, PR-A3.3 — FR-C1/C2/C3)
+  'nonce_unique_per_signer_window',
+  'sequence_monotonic_per_cluster',
+  'chain_validator_prev_hash',
 ] as const;
 
 export type EvaluatorBuiltin = typeof EVALUATOR_BUILTINS[number];

--- a/src/constraints/unverified-obligations.ts
+++ b/src/constraints/unverified-obligations.ts
@@ -42,10 +42,18 @@ import type { Constraint, ConstraintFile } from './types.js';
  */
 export type UnverifiedObligationReason =
   | 'chain_context_provided'
+  | 'chain_ledger_mismatch'
+  | 'chain_prev_hash_mismatch'
+  | 'cluster_id_mismatch'
   | 'context_absent'
   | 'crypto_deferred'
   | 'integrity_deferred'
+  | 'key_version_regression'
+  | 'nonce_context_deferred'
+  | 'nonce_replay_detected'
   | 'pattern_matching'
+  | 'sequence_context_deferred'
+  | 'sequence_monotonic_violation'
   | 'vocabulary_drift';
 
 export interface UnverifiedObligationEntry {
@@ -78,6 +86,39 @@ export interface UnverifiedObligationEntry {
    * `chain_context_provided` — FR-A4 (v8.6.0) opt-in acknowledgment that
    * the consumer supplied `chainContext.granted_by_chain_records` and
    * accepts the v9.0.0 fail-closed semantics ahead of the default flip.
+   *
+   * The following members were added in PR-A3.3 (v8.6.0, FR-C1/C2/C3) for
+   * the new state-bearing constraint builtins. Each maps one-to-one to a
+   * structured diagnostic code emitted by the corresponding builtin in
+   * `src/constraints/builtins/*.ts`:
+   *
+   * `nonce_replay_detected` — FR-C1: a `(signer_id, nonce)` pair within the
+   *   sliding-window range was already observed for this signer; the second
+   *   appearance is a replay candidate. Cross-record state-bearing.
+   * `nonce_context_deferred` — FR-C1: nonce-window state was not supplied
+   *   to validate(); the obligation is surfaced for consumer-side
+   *   evaluation (mirrors the ORD-3 `context_absent` pattern).
+   * `sequence_monotonic_violation` — FR-C2: the parsed sequence number
+   *   was less than or equal to the last-observed sequence for this
+   *   `(cluster_id, signer_id, key_version)` triple; the chain has
+   *   regressed.
+   * `sequence_context_deferred` — FR-C2: the per-cluster sequence state
+   *   was not supplied to validate(); deferred to consumer.
+   * `key_version_regression` — FR-C2: the parsed `key_version` was less
+   *   than the last-observed key_version for this cluster; key-rotation
+   *   went backward (which the protocol forbids).
+   * `chain_ledger_mismatch` — FR-C3: the audit-ledger's
+   *   `expected_prior_hash` for the validating record differs from the
+   *   `previous_hash` value the chain itself records — a divergence
+   *   between the consumer's persistent ledger and the chain payload
+   *   (NA-1: the field MUST be cross-checked, not just declared).
+   * `chain_prev_hash_mismatch` — FR-C3: within the supplied chain, a
+   *   record's `previous_hash` does not equal its predecessor's
+   *   `entry_hash`; the chain has been tampered or assembled wrong.
+   * `cluster_id_mismatch` — FR-C2 / shared: the validating record's
+   *   `cluster_id` does not match the cluster declared by the supplied
+   *   state (CT-08: this check fires BEFORE any state-map lookup so a
+   *   cross-cluster lookup cannot succeed silently).
    */
   reason?: UnverifiedObligationReason;
   /** Human explanation of the consumer obligation. */

--- a/src/constraints/unverified-obligations.ts
+++ b/src/constraints/unverified-obligations.ts
@@ -90,7 +90,20 @@ export interface UnverifiedObligationEntry {
    * The following members were added in PR-A3.3 (v8.6.0, FR-C1/C2/C3) for
    * the new state-bearing constraint builtins. Each maps one-to-one to a
    * structured diagnostic code emitted by the corresponding builtin in
-   * `src/constraints/builtins/*.ts`:
+   * `src/constraints/builtins/*.ts`.
+   *
+   * **TODO(PR-A3.4): emission-site integration** — these 8 members are
+   * present on the union (so consumers' TypeScript discriminated-union
+   * checks compile) but are NOT yet emitted by `validate()` directly.
+   * The standalone evaluators (`evaluateNonceUniquePerSignerWindow`
+   * etc.) emit them as the `code` field on their structured diagnostic
+   * surfaces; `validate()` will surface them as manifest entries via
+   * the metadata-flag dispatch pattern (`'x-nonce-bearing'` /
+   * `'x-sequence-bearing'` / `'x-chain-validator-bearing'`) when the
+   * FR-B2 PhaseCompletionEnvelopeSchema lands in PR-A3.4. The bridge
+   * iter-3 review (F-001) flagged this as a "dead-enum risk" surface
+   * — the breadcrumb here documents the integration path so future
+   * reviewers don't conclude the union members are orphaned.
    *
    * `nonce_replay_detected` — FR-C1: a `(signer_id, nonce)` pair within the
    *   sliding-window range was already observed for this signer; the second

--- a/tests/constraints/chain-validator-prev-hash.test.ts
+++ b/tests/constraints/chain-validator-prev-hash.test.ts
@@ -1,0 +1,307 @@
+/**
+ * PR-A3.3 (FR-C3) — Tests for `chain_validator_prev_hash` builtin.
+ *
+ * Acceptance hooks:
+ *   - NA-1: expected_prior_hash mismatch surfaces CHAIN_LEDGER_MISMATCH.
+ *
+ * @see src/constraints/builtins/chain-validator-prev-hash.ts
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  evaluateChainValidatorPrevHash,
+  DEFAULT_LEDGER_GENESIS_SENTINEL,
+  type ChainLedgerState,
+} from '../../src/constraints/builtins/chain-validator-prev-hash.js';
+import { evaluateConstraint } from '../../src/constraints/evaluator.js';
+
+const validChain = [
+  { entry_hash: 'h0', previous_hash: DEFAULT_LEDGER_GENESIS_SENTINEL },
+  { entry_hash: 'h1', previous_hash: 'h0' },
+  { entry_hash: 'h2', previous_hash: 'h1' },
+];
+
+function makeState(overrides: Partial<ChainLedgerState> = {}): ChainLedgerState {
+  return {
+    expected_prior_hash: new Map<number, string>(),
+    ...overrides,
+  };
+}
+
+describe('evaluateChainValidatorPrevHash (standalone)', () => {
+  describe('CHAIN_CONTEXT_DEFERRED', () => {
+    it('fires when state is undefined; valid stays true', () => {
+      const result = evaluateChainValidatorPrevHash(
+        validChain,
+        'entry_hash',
+        'previous_hash',
+        undefined,
+      );
+      expect(result.valid).toBe(true);
+      expect(result.diagnostic?.code).toBe('CHAIN_CONTEXT_DEFERRED');
+    });
+  });
+
+  describe('Empty / vacuous chains', () => {
+    it('empty chain returns valid:true', () => {
+      const result = evaluateChainValidatorPrevHash(
+        [],
+        'entry_hash',
+        'previous_hash',
+        makeState(),
+      );
+      expect(result.valid).toBe(true);
+      expect(result.diagnostic).toBeUndefined();
+    });
+  });
+
+  describe('CHAIN_GENESIS_VIOLATION', () => {
+    it('fires when first record\'s previous_hash != default sentinel', () => {
+      const chain = [
+        { entry_hash: 'h0', previous_hash: 'not-genesis' },
+        { entry_hash: 'h1', previous_hash: 'h0' },
+      ];
+      const result = evaluateChainValidatorPrevHash(
+        chain,
+        'entry_hash',
+        'previous_hash',
+        makeState(),
+      );
+      expect(result.valid).toBe(false);
+      expect(result.diagnostic?.code).toBe('CHAIN_GENESIS_VIOLATION');
+      expect(result.diagnostic?.chain_index).toBe(0);
+      expect(result.diagnostic?.expected_value).toBe(DEFAULT_LEDGER_GENESIS_SENTINEL);
+    });
+
+    it('respects custom genesis_hash override', () => {
+      const customSentinel = 'custom:genesis-anchor';
+      const chain = [
+        { entry_hash: 'h0', previous_hash: customSentinel },
+      ];
+      const result = evaluateChainValidatorPrevHash(
+        chain,
+        'entry_hash',
+        'previous_hash',
+        makeState({ genesis_hash: customSentinel }),
+      );
+      expect(result.valid).toBe(true);
+    });
+
+    it('default sentinel rejected when state declares custom one', () => {
+      const customSentinel = 'custom:genesis-anchor';
+      const chain = [
+        { entry_hash: 'h0', previous_hash: DEFAULT_LEDGER_GENESIS_SENTINEL },
+      ];
+      const result = evaluateChainValidatorPrevHash(
+        chain,
+        'entry_hash',
+        'previous_hash',
+        makeState({ genesis_hash: customSentinel }),
+      );
+      expect(result.valid).toBe(false);
+      expect(result.diagnostic?.code).toBe('CHAIN_GENESIS_VIOLATION');
+    });
+  });
+
+  describe('CHAIN_PREV_HASH_MISMATCH', () => {
+    it('fires when successor\'s previous_hash != predecessor\'s entry_hash', () => {
+      const chain = [
+        { entry_hash: 'h0', previous_hash: DEFAULT_LEDGER_GENESIS_SENTINEL },
+        { entry_hash: 'h1', previous_hash: 'WRONG' },
+      ];
+      const result = evaluateChainValidatorPrevHash(
+        chain,
+        'entry_hash',
+        'previous_hash',
+        makeState(),
+      );
+      expect(result.valid).toBe(false);
+      expect(result.diagnostic?.code).toBe('CHAIN_PREV_HASH_MISMATCH');
+      expect(result.diagnostic?.chain_index).toBe(1);
+      expect(result.diagnostic?.expected_value).toBe('h0');
+      expect(result.diagnostic?.chain_value).toBe('WRONG');
+    });
+
+    it('fires at the first broken link, not later ones', () => {
+      const chain = [
+        { entry_hash: 'h0', previous_hash: DEFAULT_LEDGER_GENESIS_SENTINEL },
+        { entry_hash: 'h1', previous_hash: 'BAD-1' },
+        { entry_hash: 'h2', previous_hash: 'BAD-2' },
+      ];
+      const result = evaluateChainValidatorPrevHash(
+        chain,
+        'entry_hash',
+        'previous_hash',
+        makeState(),
+      );
+      expect(result.diagnostic?.chain_index).toBe(1);
+    });
+  });
+
+  describe('CHAIN_LEDGER_MISMATCH (NA-1)', () => {
+    it('fires when audit-ledger expected_prior_hash differs from chain previous_hash', () => {
+      const expectedPriorHash = new Map<number, string>([
+        [1, 'expected-h0'], // ledger says chain[1].previous_hash should be 'expected-h0'
+      ]);
+      // But chain[1].previous_hash is 'h0' (matches predecessor entry_hash).
+      // The ledger's expectation diverges from the chain payload.
+      const result = evaluateChainValidatorPrevHash(
+        validChain,
+        'entry_hash',
+        'previous_hash',
+        makeState({ expected_prior_hash: expectedPriorHash }),
+      );
+      expect(result.valid).toBe(false);
+      expect(result.diagnostic?.code).toBe('CHAIN_LEDGER_MISMATCH');
+      expect(result.diagnostic?.chain_index).toBe(1);
+      expect(result.diagnostic?.chain_value).toBe('h0');
+      expect(result.diagnostic?.expected_value).toBe('expected-h0');
+    });
+
+    it('does NOT fire when audit ledger has no entry for index (consumer hasn\'t recorded yet)', () => {
+      // Ledger empty → no NA-1 cross-check; just chain-internal consistency.
+      const result = evaluateChainValidatorPrevHash(
+        validChain,
+        'entry_hash',
+        'previous_hash',
+        makeState({ expected_prior_hash: new Map() }),
+      );
+      expect(result.valid).toBe(true);
+    });
+
+    it('does NOT fire when audit ledger entry matches chain payload', () => {
+      const expectedPriorHash = new Map<number, string>([
+        [0, DEFAULT_LEDGER_GENESIS_SENTINEL],
+        [1, 'h0'],
+        [2, 'h1'],
+      ]);
+      const result = evaluateChainValidatorPrevHash(
+        validChain,
+        'entry_hash',
+        'previous_hash',
+        makeState({ expected_prior_hash: expectedPriorHash }),
+      );
+      expect(result.valid).toBe(true);
+    });
+
+    it('NA-1 fires at the FIRST divergence index (not the last)', () => {
+      const expectedPriorHash = new Map<number, string>([
+        [1, 'WRONG-1'], // first divergence at index 1
+        [2, 'WRONG-2'], // also wrong at 2 but should not be reached
+      ]);
+      const result = evaluateChainValidatorPrevHash(
+        validChain,
+        'entry_hash',
+        'previous_hash',
+        makeState({ expected_prior_hash: expectedPriorHash }),
+      );
+      expect(result.diagnostic?.code).toBe('CHAIN_LEDGER_MISMATCH');
+      expect(result.diagnostic?.chain_index).toBe(1);
+    });
+  });
+
+  describe('Happy path', () => {
+    it('valid chain with no audit-ledger expectations passes', () => {
+      const result = evaluateChainValidatorPrevHash(
+        validChain,
+        'entry_hash',
+        'previous_hash',
+        makeState(),
+      );
+      expect(result.valid).toBe(true);
+      expect(result.diagnostic).toBeUndefined();
+    });
+
+    it('single-record chain at genesis passes', () => {
+      const result = evaluateChainValidatorPrevHash(
+        [{ entry_hash: 'h0', previous_hash: DEFAULT_LEDGER_GENESIS_SENTINEL }],
+        'entry_hash',
+        'previous_hash',
+        makeState(),
+      );
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('CHAIN_INVALID_INPUT', () => {
+    it('rejects non-array chain', () => {
+      const result = evaluateChainValidatorPrevHash(
+        'not-an-array',
+        'entry_hash',
+        'previous_hash',
+        makeState(),
+      );
+      expect(result.valid).toBe(false);
+      expect(result.diagnostic?.code).toBe('CHAIN_INVALID_INPUT');
+    });
+
+    it('rejects record without string entry_hash', () => {
+      const chain = [
+        { entry_hash: 42, previous_hash: DEFAULT_LEDGER_GENESIS_SENTINEL },
+      ];
+      const result = evaluateChainValidatorPrevHash(
+        chain,
+        'entry_hash',
+        'previous_hash',
+        makeState(),
+      );
+      expect(result.valid).toBe(false);
+      expect(result.diagnostic?.code).toBe('CHAIN_INVALID_INPUT');
+    });
+
+    it('rejects null record in chain', () => {
+      const chain = [
+        { entry_hash: 'h0', previous_hash: DEFAULT_LEDGER_GENESIS_SENTINEL },
+        null,
+      ];
+      const result = evaluateChainValidatorPrevHash(
+        chain,
+        'entry_hash',
+        'previous_hash',
+        makeState(),
+      );
+      expect(result.valid).toBe(false);
+      expect(result.diagnostic?.code).toBe('CHAIN_INVALID_INPUT');
+      expect(result.diagnostic?.chain_index).toBe(1);
+    });
+  });
+});
+
+describe('chain_validator_prev_hash (constraint-DSL wrapper)', () => {
+  it('returns true when state is absent (deferred → DSL passes)', () => {
+    const data = { chain: validChain };
+    const result = evaluateConstraint(
+      data,
+      "chain_validator_prev_hash(chain, 'entry_hash', 'previous_hash')",
+    );
+    expect(result).toBe(true);
+  });
+
+  it('returns false when chain has broken link', () => {
+    const data = {
+      chain: [
+        { entry_hash: 'h0', previous_hash: DEFAULT_LEDGER_GENESIS_SENTINEL },
+        { entry_hash: 'h1', previous_hash: 'WRONG' },
+      ],
+    };
+    const result = evaluateConstraint(
+      data,
+      "chain_validator_prev_hash(chain, 'entry_hash', 'previous_hash')",
+      { chain_ledger: makeState() },
+    );
+    expect(result).toBe(false);
+  });
+
+  it('returns false when audit ledger diverges (NA-1)', () => {
+    const data = { chain: validChain };
+    const result = evaluateConstraint(
+      data,
+      "chain_validator_prev_hash(chain, 'entry_hash', 'previous_hash')",
+      {
+        chain_ledger: makeState({
+          expected_prior_hash: new Map<number, string>([[1, 'WRONG']]),
+        }),
+      },
+    );
+    expect(result).toBe(false);
+  });
+});

--- a/tests/constraints/chain-validator-prev-hash.test.ts
+++ b/tests/constraints/chain-validator-prev-hash.test.ts
@@ -183,6 +183,27 @@ describe('evaluateChainValidatorPrevHash (standalone)', () => {
       expect(result.valid).toBe(true);
     });
 
+    it('NA-1 fires at index 0 when ledger expects something other than the genesis sentinel', () => {
+      // The genesis-position case: chain[0].previous_hash equals the
+      // sentinel (passes structural genesis check), but the audit ledger
+      // recorded a different expectation for index 0. NA-1 must win over
+      // the implicit genesis-pass.
+      const expectedPriorHash = new Map<number, string>([
+        [0, 'ledger-says-different-genesis'],
+      ]);
+      const result = evaluateChainValidatorPrevHash(
+        validChain,
+        'entry_hash',
+        'previous_hash',
+        makeState({ expected_prior_hash: expectedPriorHash }),
+      );
+      expect(result.valid).toBe(false);
+      expect(result.diagnostic?.code).toBe('CHAIN_LEDGER_MISMATCH');
+      expect(result.diagnostic?.chain_index).toBe(0);
+      expect(result.diagnostic?.chain_value).toBe(DEFAULT_LEDGER_GENESIS_SENTINEL);
+      expect(result.diagnostic?.expected_value).toBe('ledger-says-different-genesis');
+    });
+
     it('NA-1 fires at the FIRST divergence index (not the last)', () => {
       const expectedPriorHash = new Map<number, string>([
         [1, 'WRONG-1'], // first divergence at index 1

--- a/tests/constraints/chain-validator-prev-hash.test.ts
+++ b/tests/constraints/chain-validator-prev-hash.test.ts
@@ -222,6 +222,38 @@ describe('evaluateChainValidatorPrevHash (standalone)', () => {
     });
   });
 
+  describe('Runtime shape validation (iter-1 HIGH F-002 mitigation)', () => {
+    it('rejects state.expected_prior_hash as plain object → CHAIN_INVALID_INPUT', () => {
+      const malformedState = {
+        // Plain object, NOT a Map — typical JSON-deserialization shape.
+        expected_prior_hash: { 1: 'h0' } as unknown as ReadonlyMap<number, string>,
+      };
+      const result = evaluateChainValidatorPrevHash(
+        validChain,
+        'entry_hash',
+        'previous_hash',
+        malformedState as never,
+      );
+      expect(result.valid).toBe(false);
+      expect(result.diagnostic?.code).toBe('CHAIN_INVALID_INPUT');
+      expect(result.diagnostic?.message).toContain('Map instance');
+    });
+
+    it('rejects state.expected_prior_hash as null', () => {
+      const malformedState = {
+        expected_prior_hash: null as unknown as ReadonlyMap<number, string>,
+      };
+      const result = evaluateChainValidatorPrevHash(
+        validChain,
+        'entry_hash',
+        'previous_hash',
+        malformedState as never,
+      );
+      expect(result.valid).toBe(false);
+      expect(result.diagnostic?.code).toBe('CHAIN_INVALID_INPUT');
+    });
+  });
+
   describe('CHAIN_INVALID_INPUT', () => {
     it('rejects non-array chain', () => {
       const result = evaluateChainValidatorPrevHash(

--- a/tests/constraints/constraint-ast-node.test.ts
+++ b/tests/constraints/constraint-ast-node.test.ts
@@ -126,10 +126,10 @@ describe('Evaluator correctness after F-020 typing', () => {
 
 describe('EVALUATOR_BUILTINS count tracks the registered set', () => {
   it('EVALUATOR_BUILTINS contains the registered set of builtins', () => {
-    expect(EVALUATOR_BUILTINS).toHaveLength(44);
+    expect(EVALUATOR_BUILTINS).toHaveLength(47);
   });
 
   it('EVALUATOR_BUILTIN_SPECS has one spec per registered builtin', () => {
-    expect(EVALUATOR_BUILTIN_SPECS.size).toBe(44);
+    expect(EVALUATOR_BUILTIN_SPECS.size).toBe(47);
   });
 });

--- a/tests/constraints/coordination-builtins.test.ts
+++ b/tests/constraints/coordination-builtins.test.ts
@@ -15,11 +15,11 @@ import { EVALUATOR_BUILTIN_SPECS } from '../../src/constraints/evaluator-spec.js
 
 describe('EVALUATOR_BUILTINS count tracks the registered set', () => {
   it('EVALUATOR_BUILTINS contains the registered set of builtins', () => {
-    expect(EVALUATOR_BUILTINS).toHaveLength(44);
+    expect(EVALUATOR_BUILTINS).toHaveLength(47);
   });
 
   it('EVALUATOR_BUILTIN_SPECS has one spec per registered builtin', () => {
-    expect(EVALUATOR_BUILTIN_SPECS.size).toBe(44);
+    expect(EVALUATOR_BUILTIN_SPECS.size).toBe(47);
   });
 
   it('new builtins are registered', () => {

--- a/tests/constraints/evaluator-registry.test.ts
+++ b/tests/constraints/evaluator-registry.test.ts
@@ -56,7 +56,7 @@ function extractTestedFunctionCalls(): Set<string> {
 
 describe('Evaluator function registry', () => {
   it('EVALUATOR_BUILTINS contains the registered set of functions', () => {
-    expect(EVALUATOR_BUILTINS).toHaveLength(44);
+    expect(EVALUATOR_BUILTINS).toHaveLength(47);
   });
 
   it('EVALUATOR_BUILTINS is frozen (const tuple)', () => {

--- a/tests/constraints/evaluator-spec.test.ts
+++ b/tests/constraints/evaluator-spec.test.ts
@@ -21,7 +21,7 @@ describe('EvaluatorBuiltinSpec registry', () => {
   });
 
   it('has one spec per registered builtin', () => {
-    expect(EVALUATOR_BUILTIN_SPECS.size).toBe(44);
+    expect(EVALUATOR_BUILTIN_SPECS.size).toBe(47);
   });
 
   for (const builtin of EVALUATOR_BUILTINS) {

--- a/tests/constraints/governance-builtins.test.ts
+++ b/tests/constraints/governance-builtins.test.ts
@@ -273,7 +273,7 @@ describe('proposal_weights_normalized', () => {
 
 describe('All registered builtins in registry', () => {
   it('EVALUATOR_BUILTINS contains the registered set of builtins', () => {
-    expect(EVALUATOR_BUILTINS).toHaveLength(44);
+    expect(EVALUATOR_BUILTINS).toHaveLength(47);
   });
 
   it('includes monetary_policy_solvent', () => {
@@ -289,7 +289,7 @@ describe('All registered builtins in registry', () => {
   });
 
   it('EVALUATOR_BUILTIN_SPECS has one spec per registered builtin', () => {
-    expect(EVALUATOR_BUILTIN_SPECS.size).toBe(44);
+    expect(EVALUATOR_BUILTIN_SPECS.size).toBe(47);
   });
 
   it('spec examples execute correctly for monetary_policy_solvent', () => {

--- a/tests/constraints/nonce-unique-per-signer-window.test.ts
+++ b/tests/constraints/nonce-unique-per-signer-window.test.ts
@@ -206,6 +206,66 @@ describe('Runtime shape validation (iter-2 HIGH F-001 mitigation)', () => {
     expect(result.diagnostic?.code).toBe('NONCE_INVALID_INPUT');
   });
 
+  it('iter-3 F-002: rejects window_seconds = NaN', () => {
+    const malformedState: NonceWindowState = {
+      window_seconds: NaN,
+      per_signer: new Map(),
+    };
+    const result = evaluateNonceUniquePerSignerWindow(
+      baseRecord,
+      'signer_id',
+      'nonce',
+      malformedState,
+    );
+    expect(result.valid).toBe(false);
+    expect(result.diagnostic?.code).toBe('NONCE_INVALID_INPUT');
+    expect(result.diagnostic?.message).toContain('window_seconds');
+  });
+
+  it('iter-3 F-002: rejects window_seconds = -5 (negative)', () => {
+    const malformedState: NonceWindowState = {
+      window_seconds: -5,
+      per_signer: new Map(),
+    };
+    const result = evaluateNonceUniquePerSignerWindow(
+      baseRecord,
+      'signer_id',
+      'nonce',
+      malformedState,
+    );
+    expect(result.valid).toBe(false);
+    expect(result.diagnostic?.code).toBe('NONCE_INVALID_INPUT');
+  });
+
+  it('iter-3 F-002: rejects window_seconds = Infinity', () => {
+    const malformedState: NonceWindowState = {
+      window_seconds: Infinity,
+      per_signer: new Map(),
+    };
+    const result = evaluateNonceUniquePerSignerWindow(
+      baseRecord,
+      'signer_id',
+      'nonce',
+      malformedState,
+    );
+    expect(result.valid).toBe(false);
+    expect(result.diagnostic?.code).toBe('NONCE_INVALID_INPUT');
+  });
+
+  it('iter-3 F-002: accepts window_seconds = 0 (boundary)', () => {
+    const state: NonceWindowState = {
+      window_seconds: 0,
+      per_signer: new Map(),
+    };
+    const result = evaluateNonceUniquePerSignerWindow(
+      baseRecord,
+      'signer_id',
+      'nonce',
+      state,
+    );
+    expect(result.valid).toBe(true);
+  });
+
   it('passes when bucket is undefined (signer not in map)', () => {
     // The undefined-bucket case must NOT trigger the inner-Set guard;
     // it's the legitimate "fresh signer" path.

--- a/tests/constraints/nonce-unique-per-signer-window.test.ts
+++ b/tests/constraints/nonce-unique-per-signer-window.test.ts
@@ -1,0 +1,167 @@
+/**
+ * PR-A3.3 (FR-C1) — Tests for `nonce_unique_per_signer_window` builtin.
+ *
+ * Covers both the standalone evaluator (structured diagnostic surface)
+ * and the constraint-DSL wrapper (boolean surface).
+ *
+ * @see src/constraints/builtins/nonce-unique-per-signer-window.ts
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  evaluateNonceUniquePerSignerWindow,
+  type NonceWindowState,
+} from '../../src/constraints/builtins/nonce-unique-per-signer-window.js';
+import { evaluateConstraint } from '../../src/constraints/evaluator.js';
+
+const baseRecord = { signer_id: 'agent-a', nonce: 'n-001' };
+
+function makeState(overrides: Partial<NonceWindowState> = {}): NonceWindowState {
+  return {
+    window_seconds: 300,
+    per_signer: new Map<string, ReadonlySet<string>>([
+      ['agent-a', new Set(['n-001', 'n-002'])],
+      ['agent-b', new Set(['m-100'])],
+    ]),
+    ...overrides,
+  };
+}
+
+describe('evaluateNonceUniquePerSignerWindow (standalone)', () => {
+  describe('NONCE_REPLAY_DETECTED', () => {
+    it('fires when nonce already seen for same signer', () => {
+      const result = evaluateNonceUniquePerSignerWindow(
+        baseRecord,
+        'signer_id',
+        'nonce',
+        makeState(),
+      );
+      expect(result.valid).toBe(false);
+      expect(result.diagnostic?.code).toBe('NONCE_REPLAY_DETECTED');
+      expect(result.diagnostic?.signer_id).toBe('agent-a');
+      expect(result.diagnostic?.nonce).toBe('n-001');
+    });
+
+    it('does NOT fire when same nonce seen for DIFFERENT signer', () => {
+      const result = evaluateNonceUniquePerSignerWindow(
+        { signer_id: 'agent-c', nonce: 'n-001' },
+        'signer_id',
+        'nonce',
+        makeState(),
+      );
+      expect(result.valid).toBe(true);
+      expect(result.diagnostic).toBeUndefined();
+    });
+
+    it('does NOT fire on fresh nonce for known signer', () => {
+      const result = evaluateNonceUniquePerSignerWindow(
+        { signer_id: 'agent-a', nonce: 'n-999' },
+        'signer_id',
+        'nonce',
+        makeState(),
+      );
+      expect(result.valid).toBe(true);
+    });
+
+    it('does NOT fire when signer not in per_signer map at all', () => {
+      const result = evaluateNonceUniquePerSignerWindow(
+        { signer_id: 'agent-z', nonce: 'anything' },
+        'signer_id',
+        'nonce',
+        makeState(),
+      );
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('NONCE_CONTEXT_DEFERRED', () => {
+    it('fires when state is undefined; valid stays true (deferred to consumer)', () => {
+      const result = evaluateNonceUniquePerSignerWindow(
+        baseRecord,
+        'signer_id',
+        'nonce',
+        undefined,
+      );
+      expect(result.valid).toBe(true);
+      expect(result.diagnostic?.code).toBe('NONCE_CONTEXT_DEFERRED');
+      expect(result.diagnostic?.signer_id).toBe('agent-a');
+    });
+  });
+
+  describe('NONCE_INVALID_INPUT', () => {
+    it('rejects null record', () => {
+      const result = evaluateNonceUniquePerSignerWindow(null, 'signer_id', 'nonce', makeState());
+      expect(result.valid).toBe(false);
+      expect(result.diagnostic?.code).toBe('NONCE_INVALID_INPUT');
+    });
+
+    it('rejects array as record', () => {
+      const result = evaluateNonceUniquePerSignerWindow([], 'signer_id', 'nonce', makeState());
+      expect(result.valid).toBe(false);
+      expect(result.diagnostic?.code).toBe('NONCE_INVALID_INPUT');
+    });
+
+    it('rejects record missing signer_id field', () => {
+      const result = evaluateNonceUniquePerSignerWindow(
+        { nonce: 'n-001' },
+        'signer_id',
+        'nonce',
+        makeState(),
+      );
+      expect(result.valid).toBe(false);
+      expect(result.diagnostic?.code).toBe('NONCE_INVALID_INPUT');
+    });
+
+    it('rejects non-string signer_id', () => {
+      const result = evaluateNonceUniquePerSignerWindow(
+        { signer_id: 42, nonce: 'n-001' },
+        'signer_id',
+        'nonce',
+        makeState(),
+      );
+      expect(result.valid).toBe(false);
+      expect(result.diagnostic?.code).toBe('NONCE_INVALID_INPUT');
+    });
+
+    it('rejects non-string nonce', () => {
+      const result = evaluateNonceUniquePerSignerWindow(
+        { signer_id: 'agent-a', nonce: 42 },
+        'signer_id',
+        'nonce',
+        makeState(),
+      );
+      expect(result.valid).toBe(false);
+      expect(result.diagnostic?.code).toBe('NONCE_INVALID_INPUT');
+    });
+  });
+});
+
+describe('nonce_unique_per_signer_window (constraint-DSL wrapper)', () => {
+  it('returns true when window state is absent (deferred → DSL passes)', () => {
+    const data = { record: baseRecord };
+    const result = evaluateConstraint(
+      data,
+      "nonce_unique_per_signer_window(record, 'signer_id', 'nonce')",
+    );
+    expect(result).toBe(true);
+  });
+
+  it('returns false when nonce is in window (replay detected)', () => {
+    const data = { record: baseRecord };
+    const result = evaluateConstraint(
+      data,
+      "nonce_unique_per_signer_window(record, 'signer_id', 'nonce')",
+      { nonce_window: makeState() },
+    );
+    expect(result).toBe(false);
+  });
+
+  it('returns true when nonce is fresh', () => {
+    const data = { record: { signer_id: 'agent-a', nonce: 'n-fresh' } };
+    const result = evaluateConstraint(
+      data,
+      "nonce_unique_per_signer_window(record, 'signer_id', 'nonce')",
+      { nonce_window: makeState() },
+    );
+    expect(result).toBe(true);
+  });
+});

--- a/tests/constraints/nonce-unique-per-signer-window.test.ts
+++ b/tests/constraints/nonce-unique-per-signer-window.test.ts
@@ -11,6 +11,7 @@ import {
   evaluateNonceUniquePerSignerWindow,
   type NonceWindowState,
 } from '../../src/constraints/builtins/nonce-unique-per-signer-window.js';
+// `makeState` is defined later in this file; the runtime-shape tests use it.
 import { evaluateConstraint } from '../../src/constraints/evaluator.js';
 
 const baseRecord = { signer_id: 'agent-a', nonce: 'n-001' };
@@ -132,6 +133,90 @@ describe('evaluateNonceUniquePerSignerWindow (standalone)', () => {
       expect(result.valid).toBe(false);
       expect(result.diagnostic?.code).toBe('NONCE_INVALID_INPUT');
     });
+  });
+});
+
+describe('Runtime shape validation (iter-2 HIGH F-001 mitigation)', () => {
+  it('rejects state.per_signer as plain object → NONCE_INVALID_INPUT', () => {
+    const malformedState = {
+      window_seconds: 300,
+      // JSON-revived state typically deserializes Map → plain object.
+      per_signer: { 'agent-a': new Set(['n-001']) } as unknown as ReadonlyMap<string, ReadonlySet<string>>,
+    };
+    const result = evaluateNonceUniquePerSignerWindow(
+      baseRecord,
+      'signer_id',
+      'nonce',
+      malformedState as never,
+    );
+    expect(result.valid).toBe(false);
+    expect(result.diagnostic?.code).toBe('NONCE_INVALID_INPUT');
+    expect(result.diagnostic?.message).toContain('Map instance');
+  });
+
+  it('rejects state.per_signer as null', () => {
+    const malformedState = {
+      window_seconds: 300,
+      per_signer: null as unknown as ReadonlyMap<string, ReadonlySet<string>>,
+    };
+    const result = evaluateNonceUniquePerSignerWindow(
+      baseRecord,
+      'signer_id',
+      'nonce',
+      malformedState as never,
+    );
+    expect(result.valid).toBe(false);
+    expect(result.diagnostic?.code).toBe('NONCE_INVALID_INPUT');
+  });
+
+  it('rejects bucket as Array (JSON-revived Set) → NONCE_INVALID_INPUT', () => {
+    const malformedState: NonceWindowState = {
+      window_seconds: 300,
+      // Outer Map is correct shape; inner bucket got JSON-revived as Array.
+      per_signer: new Map<string, ReadonlySet<string>>([
+        ['agent-a', ['n-001'] as unknown as ReadonlySet<string>],
+      ]),
+    };
+    const result = evaluateNonceUniquePerSignerWindow(
+      baseRecord,
+      'signer_id',
+      'nonce',
+      malformedState,
+    );
+    expect(result.valid).toBe(false);
+    expect(result.diagnostic?.code).toBe('NONCE_INVALID_INPUT');
+    expect(result.diagnostic?.message).toContain('Set instance');
+    expect(result.diagnostic?.signer_id).toBe('agent-a');
+  });
+
+  it('rejects bucket as plain object', () => {
+    const malformedState: NonceWindowState = {
+      window_seconds: 300,
+      per_signer: new Map<string, ReadonlySet<string>>([
+        ['agent-a', { 'n-001': true } as unknown as ReadonlySet<string>],
+      ]),
+    };
+    const result = evaluateNonceUniquePerSignerWindow(
+      baseRecord,
+      'signer_id',
+      'nonce',
+      malformedState,
+    );
+    expect(result.valid).toBe(false);
+    expect(result.diagnostic?.code).toBe('NONCE_INVALID_INPUT');
+  });
+
+  it('passes when bucket is undefined (signer not in map)', () => {
+    // The undefined-bucket case must NOT trigger the inner-Set guard;
+    // it's the legitimate "fresh signer" path.
+    const result = evaluateNonceUniquePerSignerWindow(
+      { signer_id: 'unknown-signer', nonce: 'n-x' },
+      'signer_id',
+      'nonce',
+      makeState(),
+    );
+    expect(result.valid).toBe(true);
+    expect(result.diagnostic).toBeUndefined();
   });
 });
 

--- a/tests/constraints/sequence-monotonic-per-cluster.test.ts
+++ b/tests/constraints/sequence-monotonic-per-cluster.test.ts
@@ -1,0 +1,345 @@
+/**
+ * PR-A3.3 (FR-C2) — Tests for `sequence_monotonic_per_cluster` builtin.
+ *
+ * Acceptance hooks:
+ *   - CT-08: cluster_id mismatch fires BEFORE state-map lookup.
+ *   - CT-03: string→BigInt parse uses regex pre-validator (no try/catch).
+ *
+ * @see src/constraints/builtins/sequence-monotonic-per-cluster.ts
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  evaluateSequenceMonotonicPerCluster,
+  composeSequenceKey,
+  type SequenceClusterState,
+} from '../../src/constraints/builtins/sequence-monotonic-per-cluster.js';
+import { evaluateConstraint } from '../../src/constraints/evaluator.js';
+
+const baseRecord = {
+  cluster_id: 'c1',
+  signer_id: 's1',
+  sequence: '5',
+  key_version: '0',
+};
+
+function makeState(overrides: Partial<SequenceClusterState> = {}): SequenceClusterState {
+  return {
+    cluster_id: 'c1',
+    highest_key_version: '0',
+    last_sequence: new Map<string, string>([
+      [composeSequenceKey('s1', '0'), '4'],
+      [composeSequenceKey('s2', '0'), '10'],
+    ]),
+    ...overrides,
+  };
+}
+
+describe('evaluateSequenceMonotonicPerCluster (standalone)', () => {
+  describe('CT-08 cluster-id mismatch precedes state lookup', () => {
+    it('fires CLUSTER_ID_MISMATCH when record cluster differs from state cluster', () => {
+      const result = evaluateSequenceMonotonicPerCluster(
+        { ...baseRecord, cluster_id: 'c2' },
+        'cluster_id',
+        'signer_id',
+        'sequence',
+        'key_version',
+        makeState({ cluster_id: 'c1' }),
+      );
+      expect(result.valid).toBe(false);
+      expect(result.diagnostic?.code).toBe('CLUSTER_ID_MISMATCH');
+      expect(result.diagnostic?.cluster_id).toBe('c2');
+    });
+
+    it('CT-08 mismatch check fires BEFORE last_sequence Map.get is called', () => {
+      const lastSequenceMap = new Map<string, string>();
+      const getSpy = vi.spyOn(lastSequenceMap, 'get');
+      const state: SequenceClusterState = {
+        cluster_id: 'c1',
+        highest_key_version: '0',
+        last_sequence: lastSequenceMap,
+      };
+      const result = evaluateSequenceMonotonicPerCluster(
+        { ...baseRecord, cluster_id: 'c2' },
+        'cluster_id',
+        'signer_id',
+        'sequence',
+        'key_version',
+        state,
+      );
+      expect(result.valid).toBe(false);
+      expect(result.diagnostic?.code).toBe('CLUSTER_ID_MISMATCH');
+      expect(getSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('SEQUENCE_CONTEXT_DEFERRED', () => {
+    it('fires when state is undefined; valid stays true', () => {
+      const result = evaluateSequenceMonotonicPerCluster(
+        baseRecord,
+        'cluster_id',
+        'signer_id',
+        'sequence',
+        'key_version',
+        undefined,
+      );
+      expect(result.valid).toBe(true);
+      expect(result.diagnostic?.code).toBe('SEQUENCE_CONTEXT_DEFERRED');
+    });
+  });
+
+  describe('CT-03 string→BigInt parsing without try/catch', () => {
+    it('rejects non-numeric sequence as SEQUENCE_INVALID_INPUT (no throw)', () => {
+      const result = evaluateSequenceMonotonicPerCluster(
+        { ...baseRecord, sequence: 'not-a-number' },
+        'cluster_id',
+        'signer_id',
+        'sequence',
+        'key_version',
+        makeState(),
+      );
+      expect(result.valid).toBe(false);
+      expect(result.diagnostic?.code).toBe('SEQUENCE_INVALID_INPUT');
+    });
+
+    it('rejects sequence with leading zero (other than "0")', () => {
+      const result = evaluateSequenceMonotonicPerCluster(
+        { ...baseRecord, sequence: '007' },
+        'cluster_id',
+        'signer_id',
+        'sequence',
+        'key_version',
+        makeState(),
+      );
+      expect(result.valid).toBe(false);
+      expect(result.diagnostic?.code).toBe('SEQUENCE_INVALID_INPUT');
+    });
+
+    it('rejects negative-signed sequence', () => {
+      const result = evaluateSequenceMonotonicPerCluster(
+        { ...baseRecord, sequence: '-5' },
+        'cluster_id',
+        'signer_id',
+        'sequence',
+        'key_version',
+        makeState(),
+      );
+      expect(result.valid).toBe(false);
+      expect(result.diagnostic?.code).toBe('SEQUENCE_INVALID_INPUT');
+    });
+
+    it('accepts "0" sequence (canonical zero)', () => {
+      const state = makeState({
+        last_sequence: new Map<string, string>(),
+      });
+      const result = evaluateSequenceMonotonicPerCluster(
+        { ...baseRecord, sequence: '0' },
+        'cluster_id',
+        'signer_id',
+        'sequence',
+        'key_version',
+        state,
+      );
+      expect(result.valid).toBe(true);
+    });
+
+    it('accepts very-large BigInt-class sequence', () => {
+      const huge = '99999999999999999999999999';
+      const state = makeState({
+        last_sequence: new Map<string, string>([
+          [composeSequenceKey('s1', '0'), '99999999999999999999999998'],
+        ]),
+      });
+      const result = evaluateSequenceMonotonicPerCluster(
+        { ...baseRecord, sequence: huge },
+        'cluster_id',
+        'signer_id',
+        'sequence',
+        'key_version',
+        state,
+      );
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('KEY_VERSION_REGRESSION', () => {
+    it('fires when record key_version < state highest_key_version', () => {
+      const result = evaluateSequenceMonotonicPerCluster(
+        { ...baseRecord, key_version: '2' },
+        'cluster_id',
+        'signer_id',
+        'sequence',
+        'key_version',
+        makeState({ highest_key_version: '5' }),
+      );
+      expect(result.valid).toBe(false);
+      expect(result.diagnostic?.code).toBe('KEY_VERSION_REGRESSION');
+      expect(result.diagnostic?.last_observed).toBe('5');
+      expect(result.diagnostic?.asserted).toBe('2');
+    });
+
+    it('does NOT fire when key_version equals highest', () => {
+      const result = evaluateSequenceMonotonicPerCluster(
+        baseRecord,
+        'cluster_id',
+        'signer_id',
+        'sequence',
+        'key_version',
+        makeState({ highest_key_version: '0' }),
+      );
+      // sequence 5 > last 4 → valid
+      expect(result.valid).toBe(true);
+    });
+
+    it('does NOT fire when key_version exceeds highest (forward rotation)', () => {
+      const result = evaluateSequenceMonotonicPerCluster(
+        { ...baseRecord, key_version: '7' },
+        'cluster_id',
+        'signer_id',
+        'sequence',
+        'key_version',
+        makeState({
+          highest_key_version: '5',
+          last_sequence: new Map<string, string>(),
+        }),
+      );
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('SEQUENCE_MONOTONIC_VIOLATION', () => {
+    it('fires when record sequence equals last-observed', () => {
+      const result = evaluateSequenceMonotonicPerCluster(
+        { ...baseRecord, sequence: '4' },
+        'cluster_id',
+        'signer_id',
+        'sequence',
+        'key_version',
+        makeState(),
+      );
+      expect(result.valid).toBe(false);
+      expect(result.diagnostic?.code).toBe('SEQUENCE_MONOTONIC_VIOLATION');
+      expect(result.diagnostic?.last_observed).toBe('4');
+      expect(result.diagnostic?.asserted).toBe('4');
+    });
+
+    it('fires when record sequence less than last-observed', () => {
+      const result = evaluateSequenceMonotonicPerCluster(
+        { ...baseRecord, sequence: '3' },
+        'cluster_id',
+        'signer_id',
+        'sequence',
+        'key_version',
+        makeState(),
+      );
+      expect(result.valid).toBe(false);
+      expect(result.diagnostic?.code).toBe('SEQUENCE_MONOTONIC_VIOLATION');
+    });
+
+    it('does NOT fire when record sequence strictly greater', () => {
+      const result = evaluateSequenceMonotonicPerCluster(
+        baseRecord, // sequence 5 > last 4
+        'cluster_id',
+        'signer_id',
+        'sequence',
+        'key_version',
+        makeState(),
+      );
+      expect(result.valid).toBe(true);
+    });
+
+    it('key-rotation overlap window: same sequence under newer key_version is allowed', () => {
+      // Under key_version 0, last sequence was 4. Under key_version 1 (newer),
+      // we're allowed to start a fresh sequence count — same composite key
+      // (signer, key_version) is independent.
+      const state: SequenceClusterState = {
+        cluster_id: 'c1',
+        highest_key_version: '1',
+        last_sequence: new Map<string, string>([
+          [composeSequenceKey('s1', '0'), '4'],
+          // No entry for (s1, '1') yet — fresh under new key.
+        ]),
+      };
+      const result = evaluateSequenceMonotonicPerCluster(
+        { ...baseRecord, key_version: '1', sequence: '1' },
+        'cluster_id',
+        'signer_id',
+        'sequence',
+        'key_version',
+        state,
+      );
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('Invalid input', () => {
+    it('rejects null record', () => {
+      const result = evaluateSequenceMonotonicPerCluster(
+        null,
+        'cluster_id',
+        'signer_id',
+        'sequence',
+        'key_version',
+        makeState(),
+      );
+      expect(result.valid).toBe(false);
+      expect(result.diagnostic?.code).toBe('SEQUENCE_INVALID_INPUT');
+    });
+
+    it('rejects record missing required fields', () => {
+      const result = evaluateSequenceMonotonicPerCluster(
+        { cluster_id: 'c1' },
+        'cluster_id',
+        'signer_id',
+        'sequence',
+        'key_version',
+        makeState(),
+      );
+      expect(result.valid).toBe(false);
+      expect(result.diagnostic?.code).toBe('SEQUENCE_INVALID_INPUT');
+    });
+
+    it('rejects malformed state.highest_key_version', () => {
+      const result = evaluateSequenceMonotonicPerCluster(
+        baseRecord,
+        'cluster_id',
+        'signer_id',
+        'sequence',
+        'key_version',
+        makeState({ highest_key_version: 'bad' }),
+      );
+      expect(result.valid).toBe(false);
+      expect(result.diagnostic?.code).toBe('SEQUENCE_INVALID_INPUT');
+    });
+  });
+});
+
+describe('sequence_monotonic_per_cluster (constraint-DSL wrapper)', () => {
+  it('returns true when state is absent (deferred → DSL passes)', () => {
+    const data = { record: baseRecord };
+    const result = evaluateConstraint(
+      data,
+      "sequence_monotonic_per_cluster(record, 'cluster_id', 'signer_id', 'sequence', 'key_version')",
+    );
+    expect(result).toBe(true);
+  });
+
+  it('returns false on cluster mismatch (CT-08)', () => {
+    const data = { record: { ...baseRecord, cluster_id: 'c2' } };
+    const result = evaluateConstraint(
+      data,
+      "sequence_monotonic_per_cluster(record, 'cluster_id', 'signer_id', 'sequence', 'key_version')",
+      { sequence_state: makeState({ cluster_id: 'c1' }) },
+    );
+    expect(result).toBe(false);
+  });
+
+  it('returns false on sequence violation', () => {
+    const data = { record: { ...baseRecord, sequence: '3' } };
+    const result = evaluateConstraint(
+      data,
+      "sequence_monotonic_per_cluster(record, 'cluster_id', 'signer_id', 'sequence', 'key_version')",
+      { sequence_state: makeState() },
+    );
+    expect(result).toBe(false);
+  });
+});

--- a/tests/constraints/sequence-monotonic-per-cluster.test.ts
+++ b/tests/constraints/sequence-monotonic-per-cluster.test.ts
@@ -271,6 +271,92 @@ describe('evaluateSequenceMonotonicPerCluster (standalone)', () => {
     });
   });
 
+  describe('Runtime shape validation (iter-1 HIGH F-002/F-003 mitigation)', () => {
+    it('rejects state.last_sequence as plain object (not Map) → SEQUENCE_INVALID_INPUT', () => {
+      const malformedState = {
+        cluster_id: 'c1',
+        highest_key_version: '0',
+        // Plain object, NOT a Map — common deserialization shape.
+        last_sequence: { 's1|0': '4' } as unknown as ReadonlyMap<string, string>,
+      };
+      const result = evaluateSequenceMonotonicPerCluster(
+        baseRecord,
+        'cluster_id',
+        'signer_id',
+        'sequence',
+        'key_version',
+        malformedState as never,
+      );
+      expect(result.valid).toBe(false);
+      expect(result.diagnostic?.code).toBe('SEQUENCE_INVALID_INPUT');
+      expect(result.diagnostic?.message).toContain('Map instance');
+    });
+
+    it('rejects state.last_sequence as null', () => {
+      const malformedState = {
+        cluster_id: 'c1',
+        highest_key_version: '0',
+        last_sequence: null as unknown as ReadonlyMap<string, string>,
+      };
+      const result = evaluateSequenceMonotonicPerCluster(
+        baseRecord,
+        'cluster_id',
+        'signer_id',
+        'sequence',
+        'key_version',
+        malformedState as never,
+      );
+      expect(result.valid).toBe(false);
+      expect(result.diagnostic?.code).toBe('SEQUENCE_INVALID_INPUT');
+    });
+  });
+
+  describe('Composite-key injectivity (iter-1 MEDIUM CVE-class delimiter fix)', () => {
+    it('JSON-stringify encoding distinguishes "a|0" signer from "a" signer with "0|0" key_version', () => {
+      // Naive `|` delimiter collides: ('a|0', '0') and ('a', '0|0') both
+      // produce "a|0|0". Injective JSON encoding distinguishes them:
+      // ["a|0","0"] != ["a","0|0"]. (key_version stays numeric per CT-03;
+      // signer_id is the field that can carry a `|`.)
+      // For this test, since CT-03 forbids non-numeric key_versions, we
+      // only exercise injectivity on the signer_id axis.
+      const collidingNaiveKey = `a|0|0`;
+      const stateA: SequenceClusterState = {
+        cluster_id: 'c1',
+        highest_key_version: '0',
+        last_sequence: new Map<string, string>([
+          // Stored under signer "a|0" with key_version "0".
+          [composeSequenceKey('a|0', '0'), '99'],
+        ]),
+      };
+      // Lookup with signer "a" — different from "a|0" — should be a
+      // distinct composite key under JSON-stringify, so no collision.
+      const result = evaluateSequenceMonotonicPerCluster(
+        { cluster_id: 'c1', signer_id: 'a', sequence: '1', key_version: '0' },
+        'cluster_id',
+        'signer_id',
+        'sequence',
+        'key_version',
+        stateA,
+      );
+      // With JSON-stringify: lookup key for ('a','0') = '["a","0"]', stored
+      // key for ('a|0','0') = '["a|0","0"]' — distinct → no collision →
+      // fresh sequence → valid. Naive '|' would have produced 'a|0|0' for
+      // BOTH (collision).
+      expect(result.valid).toBe(true);
+      // Also assert directly on the encoding to prove injectivity:
+      expect(composeSequenceKey('a|0', '0')).not.toBe(composeSequenceKey('a', '0|0'));
+      // (Notional naive collision proof — the naive encoding 'a|0|0' would
+      // have been the same for both.)
+      expect(`a|0|0`).toBe(collidingNaiveKey);
+    });
+
+    it('composeSequenceKey produces stable JSON-array form', () => {
+      expect(composeSequenceKey('a', 'b')).toBe('["a","b"]');
+      expect(composeSequenceKey('a|b', 'c')).toBe('["a|b","c"]');
+      expect(composeSequenceKey('with"quote', 'ver')).toBe('["with\\"quote","ver"]');
+    });
+  });
+
   describe('Invalid input', () => {
     it('rejects null record', () => {
       const result = evaluateSequenceMonotonicPerCluster(

--- a/tests/constraints/sequence-monotonic-per-cluster.test.ts
+++ b/tests/constraints/sequence-monotonic-per-cluster.test.ts
@@ -142,6 +142,36 @@ describe('evaluateSequenceMonotonicPerCluster (standalone)', () => {
       expect(result.valid).toBe(true);
     });
 
+    it('iter-3 F11: CT-03 fires BEFORE state-absent deferral (no deferring on garbage)', () => {
+      // Malformed sequence ('007') with NO state. Pre-iter-3 ordering
+      // returned SEQUENCE_CONTEXT_DEFERRED with valid:true (deferred on
+      // garbage — Postel's-Law trap). Iter-3 reorder fires CT-03 first;
+      // SEQUENCE_INVALID_INPUT regardless of state presence.
+      const result = evaluateSequenceMonotonicPerCluster(
+        { ...baseRecord, sequence: '007' },
+        'cluster_id',
+        'signer_id',
+        'sequence',
+        'key_version',
+        undefined, // no state
+      );
+      expect(result.valid).toBe(false);
+      expect(result.diagnostic?.code).toBe('SEQUENCE_INVALID_INPUT');
+    });
+
+    it('iter-3 F11: CT-03 also fires before deferral for malformed key_version', () => {
+      const result = evaluateSequenceMonotonicPerCluster(
+        { ...baseRecord, key_version: 'not-numeric' },
+        'cluster_id',
+        'signer_id',
+        'sequence',
+        'key_version',
+        undefined,
+      );
+      expect(result.valid).toBe(false);
+      expect(result.diagnostic?.code).toBe('SEQUENCE_INVALID_INPUT');
+    });
+
     it('accepts very-large BigInt-class sequence', () => {
       const huge = '99999999999999999999999999';
       const state = makeState({

--- a/tests/constraints/tree-builtins.test.ts
+++ b/tests/constraints/tree-builtins.test.ts
@@ -111,7 +111,7 @@ describe('tree_authority_narrowing', () => {
 
 describe('EVALUATOR_BUILTINS and SPECS updated', () => {
   it('EVALUATOR_BUILTINS contains the registered set of builtins', () => {
-    expect(EVALUATOR_BUILTINS).toHaveLength(44);
+    expect(EVALUATOR_BUILTINS).toHaveLength(47);
   });
 
   it('includes tree_budget_conserved', () => {
@@ -123,7 +123,7 @@ describe('EVALUATOR_BUILTINS and SPECS updated', () => {
   });
 
   it('EVALUATOR_BUILTIN_SPECS has one spec per registered builtin', () => {
-    expect(EVALUATOR_BUILTIN_SPECS.size).toBe(44);
+    expect(EVALUATOR_BUILTIN_SPECS.size).toBe(47);
   });
 
   it('spec examples execute correctly for tree_budget_conserved', () => {

--- a/tests/constraints/type-introspection-builtins.test.ts
+++ b/tests/constraints/type-introspection-builtins.test.ts
@@ -71,7 +71,7 @@ describe('is_bigint_coercible builtin', () => {
 
 describe('EVALUATOR_BUILTINS registry', () => {
   it('contains the registered set of builtins', () => {
-    expect(EVALUATOR_BUILTINS).toHaveLength(44);
+    expect(EVALUATOR_BUILTINS).toHaveLength(47);
   });
 
   it('includes type_of', () => {
@@ -85,7 +85,7 @@ describe('EVALUATOR_BUILTINS registry', () => {
 
 describe('EVALUATOR_BUILTIN_SPECS registry', () => {
   it('has a spec for every registered builtin', () => {
-    expect(EVALUATOR_BUILTIN_SPECS.size).toBe(44);
+    expect(EVALUATOR_BUILTIN_SPECS.size).toBe(47);
   });
 
   it('has spec for type_of', () => {


### PR DESCRIPTION
## Summary

Largest non-shipping PR in cycle-005. Three new state-bearing constraint builtins with sprint-locked correctness invariants (CT-08 + NA-1 + CT-03), 8 new manifest-reason union members, and 53 new unit tests.

- **FR-C1 — `nonce_unique_per_signer_window`**: per-signer sliding-window replay detection. Three terminal codes: `NONCE_REPLAY_DETECTED`, `NONCE_CONTEXT_DEFERRED`, `NONCE_INVALID_INPUT`.
- **FR-C2 — `sequence_monotonic_per_cluster`**: per-cluster sequence + key-version monotonicity. Five terminal codes. **CT-08** cluster-id mismatch fires BEFORE any state-map lookup (verified via `vi.spyOn` confirming `state.last_sequence.get` is NOT called on the mismatch path). **CT-03** string→BigInt parsing uses `^(0|[1-9][0-9]*)$` regex pre-validator so `BigInt()` never throws.
- **FR-C3 — `chain_validator_prev_hash`**: ledger-style cluster-event chain validation, distinct from ORD-3 (`is_valid_dag`, delegation DAG). Five terminal codes. **NA-1** audit-ledger `expected_prior_hash` cross-checked against chain's on-payload `previous_hash` per index — closes the cycle-005 RC2 gap where the field was declared but never compared.
- **8 new `UnverifiedObligationReason` union members** (alphabetized for stable diff readability): `chain_ledger_mismatch`, `chain_prev_hash_mismatch`, `cluster_id_mismatch`, `key_version_regression`, `nonce_context_deferred`, `nonce_replay_detected`, `sequence_context_deferred`, `sequence_monotonic_violation`. Runtime-additive; type-strict-breaking for `assertNever` consumers.
- **`EVALUATOR_BUILTINS` widened 44 → 47** per sprint AC. `EVALUATOR_BUILTIN_SPECS` gains three full specs with ≥2 examples + edge cases each. `EvaluationContext` extended with three optional state fields (`nonce_window`, `sequence_state`, `chain_ledger`).

## Test plan

- [x] `npm run check:all` exit 0
- [x] `npm run check:constraints` exit 0 (124/124 coverage)
- [x] `npm run semver:check` exit 0 (baseline mode — version bump locked to v8.6.0 ship PR)
- [x] `npx vitest run` — 7,836 → 7,904 passing (+68 net = 53 new builtin tests + 15 count-bump assertion updates)
- [x] CT-08 ordering test: `'CT-08 mismatch check fires BEFORE last_sequence Map.get is called'` passes
- [x] NA-1 cross-check test: `'CHAIN_LEDGER_MISMATCH (NA-1)'` block passes (4 assertions)
- [x] CT-03 BigInt-without-throw: 5 assertions covering non-numeric, leading-zero, signed, canonical-zero, very-large-BigInt
- [x] Strict-additive: pre-v8.6.0 consumers calling `evaluateConstraint(data, expr)` without context get `valid:true` with deferred diagnostics
- [x] Pollution grep (canonical hook regex) on the staged diff: CLEAN
- [ ] CI workflows (`ci.yml` + `pollution-check.yml`) green on PR
- [ ] **Bridge model-swap empirical validation**: iter-1 should complete with `3 model(s) completed` and zero `Review failed` entries (validating the `gemini-3.1-pro-preview` → `gemini-2.5-pro` swap per upstream issue #789)

## Sprint reference

- Sprint plan: `grimoires/loa/sprint.md` §1 PR-A3.3
- Reviewer report: `grimoires/loa/a2a/sprint-A3.3/reviewer.md`
- FR coverage: FR-C1, FR-C2, FR-C3 (with CT-08 + NA-1 + CT-03)
- Predecessor: PR-A3.2 (`fcbc49d2`)
- Unblocks: PR-A3.4 (FR-B2 PhaseCompletionEnvelope) consumes these builtins via vector fixtures