### PR TITLE
chore(cycle-007): hoist SCHEMAS to single-source-of-truth across generate + check

### DIFF
--- a/RELEASE-INTEGRITY.json
+++ b/RELEASE-INTEGRITY.json
@@ -1,6 +1,6 @@
 {
   "release_version": "8.7.0",
-  "generated_at": "2026-05-11T06:06:40.817Z",
+  "generated_at": "2026-05-11T06:39:25.430Z",
   "generator": "generate-release-integrity.ts",
   "notes": "Authoritative manifest tracked at HEAD; see CHANGELOG.md for any post-publish corrections under the same release_version label.",
   "totals": {

--- a/scripts/check-schemas.ts
+++ b/scripts/check-schemas.ts
@@ -1,62 +1,31 @@
 /**
  * Verify that generated JSON Schema files are up to date.
  * Exit 1 if any schema is stale (needs regeneration).
+ *
+ * **Single-source-of-truth refactor** (PR-A4.1 iter-3 + PR-A4.4 iter-3
+ * lesson): this script previously maintained its own 22-entry SCHEMAS
+ * array while `scripts/generate-schemas.ts` had 262. The divergence
+ * allowed cycle-005 + cycle-007 schemas to drift silently between
+ * TypeBox source and the published artifact, surfacing as bridge
+ * HIGH_CONSENSUS findings only at the multi-model PR review tier.
+ * The script now imports `SCHEMAS` from `generate-schemas.ts` so the
+ * pre-commit `npm run schema:check` covers the full published
+ * artifact surface.
  */
 import { readFileSync, existsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { JwtClaimsSchema, S2SJwtClaimsSchema } from '../src/schemas/jwt-claims.js';
-import { InvokeResponseSchema, UsageReportSchema } from '../src/schemas/invoke-response.js';
-import { StreamEventSchema } from '../src/schemas/stream-events.js';
-import { RoutingPolicySchema } from '../src/schemas/routing-policy.js';
-import { AgentDescriptorSchema } from '../src/schemas/agent-descriptor.js';
-import { AgentLifecycleStateSchema } from '../src/schemas/agent-lifecycle.js';
-import { BillingEntrySchema, CreditNoteSchema } from '../src/schemas/billing-entry.js';
-import { ConversationSchema, MessageSchema } from '../src/schemas/conversation.js';
-import { TransferSpecSchema, TransferEventSchema } from '../src/schemas/transfer-spec.js';
-import { DomainEventSchema, DomainEventBatchSchema } from '../src/schemas/domain-event.js';
-import { LifecycleTransitionPayloadSchema } from '../src/schemas/lifecycle-event-payload.js';
-import { CapabilitySchema, CapabilityQuerySchema, CapabilityResponseSchema } from '../src/schemas/capability.js';
-import { ProtocolDiscoverySchema } from '../src/schemas/discovery.js';
-import { SagaContextSchema } from '../src/schemas/saga-context.js';
+import { SCHEMAS } from './generate-schemas.js';
 import { CONTRACT_VERSION, MIN_SUPPORTED_VERSION } from '../src/version.js';
 import { postProcessSchema } from './schema-postprocess.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const outDir = join(__dirname, '..', 'schemas');
 
-const schemas = [
-  { name: 'jwt-claims', schema: JwtClaimsSchema },
-  { name: 's2s-jwt-claims', schema: S2SJwtClaimsSchema },
-  { name: 'invoke-response', schema: InvokeResponseSchema },
-  { name: 'usage-report', schema: UsageReportSchema },
-  { name: 'stream-event', schema: StreamEventSchema },
-  { name: 'routing-policy', schema: RoutingPolicySchema },
-  // v2.0.0
-  { name: 'agent-descriptor', schema: AgentDescriptorSchema },
-  { name: 'agent-lifecycle-state', schema: AgentLifecycleStateSchema },
-  { name: 'billing-entry', schema: BillingEntrySchema },
-  { name: 'credit-note', schema: CreditNoteSchema },
-  { name: 'conversation', schema: ConversationSchema },
-  { name: 'message', schema: MessageSchema },
-  { name: 'transfer-spec', schema: TransferSpecSchema },
-  { name: 'transfer-event', schema: TransferEventSchema },
-  { name: 'domain-event', schema: DomainEventSchema },
-  // v2.1.0
-  { name: 'domain-event-batch', schema: DomainEventBatchSchema },
-  { name: 'lifecycle-transition-payload', schema: LifecycleTransitionPayloadSchema },
-  // v2.2.0
-  { name: 'capability', schema: CapabilitySchema },
-  { name: 'capability-query', schema: CapabilityQuerySchema },
-  { name: 'capability-response', schema: CapabilityResponseSchema },
-  { name: 'protocol-discovery', schema: ProtocolDiscoverySchema },
-  { name: 'saga-context', schema: SagaContextSchema },
-];
-
 let stale = false;
 
-for (const { name, schema } of schemas) {
+for (const { name, schema } of SCHEMAS) {
   const path = join(outDir, `${name}.schema.json`);
   const jsonSchema: Record<string, unknown> = {
     $schema: 'https://json-schema.org/draft/2020-12/schema',
@@ -83,7 +52,9 @@ for (const { name, schema } of schemas) {
     console.error(`STALE: ${path}`);
     stale = true;
   } else {
-    console.log(`OK: ${path}`);
+    // Suppressed per-schema OK log for the 262-entry surface; only
+    // STALE / MISSING lines and the final tally are emitted to keep
+    // CI output manageable.
   }
 }
 
@@ -92,4 +63,4 @@ if (stale) {
   process.exit(1);
 }
 
-console.log(`\nAll ${schemas.length} schemas up to date.`);
+console.log(`All ${SCHEMAS.length} schemas up to date.`);

--- a/scripts/generate-schemas.ts
+++ b/scripts/generate-schemas.ts
@@ -262,7 +262,23 @@ import { postProcessSchema } from './schema-postprocess.js';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const outDir = join(__dirname, '..', 'schemas');
 
-const schemas = [
+/**
+ * Single source of truth for the published JSON Schema artifact set.
+ *
+ * Exported so `scripts/check-schemas.ts` can iterate the same list
+ * without maintaining a parallel registry. Prior to this hoist,
+ * `check-schemas.ts` had its own 22-entry array while `generate-schemas.ts`
+ * had 262; the divergence allowed cycle-005 + cycle-007 schemas to drift
+ * silently between TypeBox source and the published artifact. The
+ * PR-A4.1 iter-3 broken-`$ref` and PR-A4.4 iter-3 stale-prose bug
+ * classes both surfaced as a bridge HIGH_CONSENSUS finding precisely
+ * because the local pre-flight didn't cover those schemas.
+ *
+ * **Contract**: every published `schemas/*.schema.json` MUST have a
+ * matching entry here so `npm run schema:check` flags any source/
+ * artifact drift across the entire surface.
+ */
+export const SCHEMAS = [
   { name: 'jwt-claims', schema: JwtClaimsSchema },
   { name: 's2s-jwt-claims', schema: S2SJwtClaimsSchema },
   { name: 'invoke-response', schema: InvokeResponseSchema },
@@ -594,9 +610,28 @@ const schemas = [
   { name: 'merge-artifact', schema: MergeArtifactSchema },
 ];
 
+// Guard the entry-point execution so `scripts/check-schemas.ts` can
+// import `SCHEMAS` without triggering schema regeneration as an
+// import side-effect. `walkAndStrip` (via postProcessSchema) mutates
+// nested objects of the generated schemas in place; without this
+// guard, importing SCHEMAS from another script would invisibly run
+// the generator AND mutate the TypeBox source object references,
+// causing the check-schemas comparison to see a moving target. The
+// `process.argv[1]` check matches the standard
+// `if __name__ == '__main__'` idiom: top-level script execution
+// runs the body; module imports get only the exported SCHEMAS.
+const isMainModule =
+  !!process.argv[1] &&
+  fileURLToPath(import.meta.url) === process.argv[1];
+
+if (!isMainModule) {
+  // Loaded by another module (e.g. check-schemas.ts importing
+  // SCHEMAS); skip the generator body.
+} else {
+
 mkdirSync(outDir, { recursive: true });
 
-for (const { name, schema } of schemas) {
+for (const { name, schema } of SCHEMAS) {
   const jsonSchema: Record<string, unknown> = {
     $schema: 'https://json-schema.org/draft/2020-12/schema',
     ...schema,
@@ -615,7 +650,7 @@ for (const { name, schema } of schemas) {
   console.log(`Generated: ${path}`);
 }
 
-console.log(`\n${schemas.length} schemas generated.`);
+console.log(`\n${SCHEMAS.length} schemas generated.`);
 
 // Generate schemas/index.json — machine-readable schema registry.
 //
@@ -636,7 +671,7 @@ const index = {
   $schema: 'https://schemas.0xhoneyjar.com/loa-hounfour/index',
   version: CONTRACT_VERSION,
   min_supported_version: MIN_SUPPORTED_VERSION,
-  schemas: schemas.map(({ name, schema }) => ({
+  schemas: SCHEMAS.map(({ name, schema }) => ({
     name,
     $id: `https://schemas.0xhoneyjar.com/loa-hounfour/${CONTRACT_VERSION}/${name}`,
     file: `${name}.schema.json`,
@@ -654,13 +689,13 @@ const readmeLines = [
   '',
   `**Contract version:** ${CONTRACT_VERSION}`,
   `**Min supported:** ${MIN_SUPPORTED_VERSION}`,
-  `**Schemas:** ${schemas.length}`,
+  `**Schemas:** ${SCHEMAS.length}`,
   '',
   '## Schemas',
   '',
   '| Schema | $id | File |',
   '|--------|-----|------|',
-  ...schemas.map(({ name }) =>
+  ...SCHEMAS.map(({ name }) =>
     `| ${name} | \`https://schemas.0xhoneyjar.com/loa-hounfour/${CONTRACT_VERSION}/${name}\` | [${name}.schema.json](${name}.schema.json) |`,
   ),
   '',
@@ -685,3 +720,5 @@ const readmeLines = [
 const readmePath = join(outDir, 'README.md');
 writeFileSync(readmePath, readmeLines.join('\n'));
 console.log(`Generated: ${readmePath}`);
+
+} // end isMainModule


### PR DESCRIPTION
## Summary

Closes the **PR-A4.1 iter-3 / PR-A4.4 iter-3 artifact-drift bug class** at the local pre-flight gate level. Both PRs hit bridge HIGH_CONSENSUS findings precisely because `npm run schema:check` locally only covered 22 of 262 published schemas.

### Before

- `scripts/check-schemas.ts`: hand-maintained 22-entry array (v2.x only)
- `scripts/generate-schemas.ts`: 262-entry array
- Cycle-005 + cycle-007 schemas drifted silently between TypeBox source and `schemas/*.schema.json`

### After

- `SCHEMAS` exported from `generate-schemas.ts`, imported by `check-schemas.ts`
- Full 262-schema surface covered by a single source of truth
- Module-import side-effects guarded behind `isMainModule` (standard `if __name__ == '__main__'` ESM idiom) so importing SCHEMAS doesn't invisibly run the generator + mutate TypeBox source objects via `walkAndStrip`

### Drift-detection regression test

Verified manually: editing a `description:` string in `src/canonical/merge-artifact.ts` (without regenerating) immediately fails `npm run schema:check` with `STALE: schemas/merge-artifact.schema.json`. Restoring the source returns the check to green.

The local pre-flight now closes the bug class that previously surfaced only at the multi-model bridge review tier.

## Test plan

- [x] `npm run check:all` green (incl. dist-parity, release-integrity-parity, tarball-budget, cross-runner-ssot, class-policy-boundary, schema-check on 262 entries)
- [x] 9,428 tests pass
- [x] Drift-detection regression confirmed (drift introduced → STALE flagged → restored → green)
- [x] Pollution-grep clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)