### PR TITLE
feat(integrity): Legba substrate schemas (cycle 1) — SpanMove, GateToken, RunReceipt

### DIFF
--- a/SCHEMA-CHANGELOG.md
+++ b/SCHEMA-CHANGELOG.md
@@ -10,6 +10,38 @@ Per-schema evolution tracking for `@0xhoneyjar/loa-hounfour`. Each entry records
 
 ## [Unreleased] — Recall Wedge composition
 
+### Legba substrate schemas (cycle 1) — proposal
+
+Three crypto/chain-bearing integrity schemas for the Legba operator substrate
+(cryptographic validation of agentic state transitions; authored in
+`loa-freeside` legba-substrate ladder, cycle 1):
+
+- **`SpanMove`** (`x-chain-bearing`) — one hash-chained move in a span log.
+  Moves are `re_executable` (allowlisted tool calls, replayable from CAS) or
+  `attestable` (emissions + hash-only tools). Intra-span chain via
+  `prev_hash`/`record_hash`. Constraints LM-1..5 (seq monotonicity, chain
+  continuity, record_hash JCS-omission derivation, env_fingerprint-iff-
+  re_executable, 4 KB canonical cap).
+- **`GateToken`** (`x-crypto-bearing`, `x-chain-bearing`) — the ed25519-signed
+  key between gates. Turnstile precondition: span N>0 refuses without gate
+  N-1's pass-token. Wave-level under DAG fan-out (`wave_number`). Constraints
+  LT-1..5 (key-id derivation, unpredictable replay_seed, token chain, signature
+  verify, split turnstile predicate). Cycle-1 transport: embedded in the
+  construct-handoff `verdict.gate_token` (no envelope schema bump).
+- **`RunReceipt`** (`x-chain-bearing`) — the token-hash chain + receipt-bound
+  key set compiled to one verifiable hash. Constraints LR-1..4 (receipt_hash
+  covers key_set, pinned genesis literal, sequence order, external audit-chain
+  anchoring).
+
+Vectors: `vectors/<Schema>/v8.8.0/{valid,invalid,invalid-cross-field}` (21
+fixtures; structural-tier runner green). Schemas pin their own `8.8.0`
+introduction literal; the global `CONTRACT_VERSION` bump is deferred to the
+release decision. **Cross-field validator implementations + registry wiring are
+a post-ratification follow-up** — the constraint files + cross-field vector
+corpus are staged so that work has its contract ready. Open questions for review
+in the PR body (version literal, pubkey encoding, status string-vs-object).
+
+
 **Theme:** Documentation + conformance-corpus surface describing how the
 existing v8.5.0 PR-A2.3 / v8.6.0 PR-A3.7 schemas compose into the
 Straylight Recall Wedge. **Strict-additive at the schema layer** — a

--- a/constraints/GateToken.constraints.json
+++ b/constraints/GateToken.constraints.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://loa-hounfour.dev/schemas/constraint-file.json",
+  "schema_id": "GateToken",
+  "origin": "genesis",
+  "contract_version": "8.8.0",
+  "expression_version": "1.0",
+  "constraints": [
+    {
+      "id": "LT-1",
+      "expression": "gatekeeper_key_id == sha256(gatekeeper_id || ':' || key_version)",
+      "severity": "error",
+      "message": "GateToken.gatekeeper_key_id MUST equal the hounfour signer-key-id derivation (reuses signer_key_id_matches_derivation).",
+      "fields": [
+        "gatekeeper_key_id",
+        "key_version"
+      ],
+      "evaluator": "library",
+      "evaluation_note": "LOCAL derivation builtin; gatekeeper_id is resolved from the trust-store by the consumer.",
+      "type_signature": {
+        "gatekeeper_key_id": "string",
+        "key_version": "integer"
+      }
+    },
+    {
+      "id": "LT-2",
+      "expression": "replay_seed == sha256(span_log_head || ed25519_sig(span_log_head, gatekeeper_key))",
+      "severity": "error",
+      "message": "GateToken.replay_seed MUST be unpredictable to the worker and reproducible by a verifier holding the token (seed binds the gatekeeper signature over the head).",
+      "fields": [
+        "replay_seed",
+        "span_log_head",
+        "signature"
+      ],
+      "evaluator": "runtime-deferred",
+      "evaluation_note": "Requires the gatekeeper's signature over span_log_head; verified consumer-side alongside the token signature.",
+      "type_signature": {
+        "replay_seed": "string",
+        "span_log_head": "string",
+        "signature": "string"
+      }
+    },
+    {
+      "id": "LT-3",
+      "expression": "prev_token_hash chains to the prior token; gate_index 0 uses the genesis anchor",
+      "severity": "error",
+      "message": "GateToken.prev_token_hash MUST chain the token sequence; gate 0 anchors with sha256:000...000 (LG-3b).",
+      "fields": [
+        "prev_token_hash",
+        "gate_index"
+      ],
+      "evaluator": "library",
+      "evaluation_note": "Cross-token continuity; the genesis anchor is bound by the run receipt.",
+      "type_signature": {
+        "prev_token_hash": "string",
+        "gate_index": "integer"
+      }
+    },
+    {
+      "id": "LT-4",
+      "expression": "ed25519 signature verifies over RFC8785 canonical json of all-other-fields, against the trust-store-resolved gatekeeper pubkey",
+      "severity": "error",
+      "message": "GateToken.signature MUST verify; hounfour does not verify, consumer-side per NF-1. Keys resolve through the loa trust-store, never bare manifest publication.",
+      "fields": [
+        "signature",
+        "gatekeeper_key_id",
+        "key_version"
+      ],
+      "evaluator": "runtime-deferred",
+      "evaluation_note": "Cryptographic verification is consumer policy.",
+      "type_signature": {
+        "signature": "string",
+        "gatekeeper_key_id": "string",
+        "key_version": "integer"
+      }
+    },
+    {
+      "id": "LT-5",
+      "expression": "turnstile split predicate: across segments gate_index == next_span_index - 1 (wave 0); within fan-out wave_number > prior.wave_number at same gate_index",
+      "severity": "error",
+      "message": "Turnstile advancement MUST satisfy the split predicate; the serial path (wave 0, gate_index bump) must work \u2014 the single-predicate form rejected every serial run after gate 0.",
+      "fields": [
+        "gate_index",
+        "wave_number"
+      ],
+      "evaluator": "runtime-deferred",
+      "evaluation_note": "Evaluated by the turnstile at dispatch; encoded here for vector coverage (serial-turnstile-regression fixture).",
+      "type_signature": {
+        "gate_index": "integer",
+        "wave_number": "integer"
+      }
+    }
+  ]
+}

--- a/constraints/RunReceipt.constraints.json
+++ b/constraints/RunReceipt.constraints.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://loa-hounfour.dev/schemas/constraint-file.json",
+  "schema_id": "RunReceipt",
+  "origin": "genesis",
+  "contract_version": "8.8.0",
+  "expression_version": "1.0",
+  "constraints": [
+    {
+      "id": "LR-1",
+      "expression": "receipt_hash == sha256(RFC8785_canonical_json({genesis_anchor, token_hash_sequence, key_set, status}))",
+      "severity": "error",
+      "message": "RunReceipt.receipt_hash MUST cover the key_set; a mutated key_set breaks the receipt (binds signer identity).",
+      "fields": [
+        "receipt_hash",
+        "genesis_anchor",
+        "token_hash_sequence",
+        "key_set",
+        "status"
+      ],
+      "evaluator": "library",
+      "evaluation_note": "Single-record derivation over the four covered fields.",
+      "type_signature": {
+        "receipt_hash": "string",
+        "genesis_anchor": "string",
+        "token_hash_sequence": "array",
+        "key_set": "array",
+        "status": "string"
+      }
+    },
+    {
+      "id": "LR-2",
+      "expression": "genesis_anchor == 'sha256:000...000' (the pinned literal)",
+      "severity": "error",
+      "message": "RunReceipt.genesis_anchor MUST be the pinned chain-root literal; no implementation-divergent roots (LG-3b).",
+      "fields": [
+        "genesis_anchor"
+      ],
+      "evaluator": "library",
+      "evaluation_note": "Literal check; also enforced by the schema's Type.Literal.",
+      "type_signature": {
+        "genesis_anchor": "string"
+      }
+    },
+    {
+      "id": "LR-3",
+      "expression": "token_hash_sequence ordered by (gate_index, wave_number) ascending",
+      "severity": "error",
+      "message": "RunReceipt.token_hash_sequence MUST be in (gate_index, wave_number) order so verifiers walk the chain deterministically.",
+      "fields": [
+        "token_hash_sequence"
+      ],
+      "evaluator": "library",
+      "evaluation_note": "Order check; requires resolving each token hash to its (gate_index, wave_number).",
+      "type_signature": {
+        "token_hash_sequence": "array"
+      }
+    },
+    {
+      "id": "LR-4",
+      "expression": "receipt_hash is emitted into the loa audit chain via audit_emit at run close",
+      "severity": "error",
+      "message": "RunReceipt.receipt_hash MUST be externally anchored; retroactive forgery must also rewrite the independent hash-chained signed audit log.",
+      "fields": [
+        "receipt_hash"
+      ],
+      "evaluator": "runtime-deferred",
+      "evaluation_note": "Consumer policy \u2014 the loa audit chain is the external anchor.",
+      "type_signature": {
+        "receipt_hash": "string"
+      }
+    }
+  ]
+}

--- a/constraints/SpanMove.constraints.json
+++ b/constraints/SpanMove.constraints.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://loa-hounfour.dev/schemas/constraint-file.json",
+  "schema_id": "SpanMove",
+  "origin": "genesis",
+  "contract_version": "8.8.0",
+  "expression_version": "1.0",
+  "constraints": [
+    {
+      "id": "LM-1",
+      "expression": "seq strictly increases by 1 per span_index, starting at 0",
+      "severity": "error",
+      "message": "SpanMove.seq MUST be strictly monotonic per span (no gaps, no repeats); a gap or repeat is a chain violation.",
+      "fields": [
+        "seq",
+        "span_index"
+      ],
+      "evaluator": "library",
+      "evaluation_note": "Cross-record (per-span) check; the library walks the span log in order.",
+      "type_signature": {
+        "seq": "integer",
+        "span_index": "integer"
+      }
+    },
+    {
+      "id": "LM-2",
+      "expression": "prev_hash equals the prior move's record_hash; the first move of a span uses the genesis anchor sha256:000...000",
+      "severity": "error",
+      "message": "SpanMove.prev_hash MUST chain to the prior move's record_hash; flipping any byte of history changes the head (LG-2).",
+      "fields": [
+        "prev_hash",
+        "record_hash"
+      ],
+      "evaluator": "library",
+      "evaluation_note": "Cross-record continuity check.",
+      "type_signature": {
+        "prev_hash": "string",
+        "record_hash": "string"
+      }
+    },
+    {
+      "id": "LM-3",
+      "expression": "record_hash equals sha256(RFC8785_canonical_json(record with the record_hash key absent))",
+      "severity": "error",
+      "message": "SpanMove.record_hash MUST be the sha256 of the canonical record with the record_hash key OMITTED before canonicalization (not empty, not null).",
+      "fields": [
+        "record_hash"
+      ],
+      "evaluator": "library",
+      "evaluation_note": "Single-record derivation; the canonicalizer omits the record_hash key.",
+      "type_signature": {
+        "record_hash": "string"
+      }
+    },
+    {
+      "id": "LM-4",
+      "expression": "env_fingerprint is present if and only if determinism == 're_executable'",
+      "severity": "error",
+      "message": "A re_executable move MUST carry env_fingerprint (LG-4b); an attestable move MUST NOT.",
+      "fields": [
+        "env_fingerprint",
+        "determinism"
+      ],
+      "evaluator": "library",
+      "evaluation_note": "Single-record conditional-presence check.",
+      "type_signature": {
+        "env_fingerprint": "string",
+        "determinism": "string"
+      }
+    },
+    {
+      "id": "LM-5",
+      "expression": "RFC8785 canonical-json byte length of the record <= 4096",
+      "severity": "error",
+      "message": "SpanMove canonical form MUST NOT exceed 4096 bytes; the recorder refuses loudly (LEGBA_MOVE_TOO_LARGE) at record time, never truncates.",
+      "fields": [
+        "record_hash"
+      ],
+      "evaluator": "library",
+      "evaluation_note": "LOCAL canonical_size_cap pattern; reads x-canonical-size-cap-bytes.",
+      "type_signature": {
+        "record_hash": "string"
+      }
+    }
+  ]
+}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -2,7 +2,7 @@
 
 **Contract version:** 8.7.0
 **Min supported:** 6.0.0
-**Schemas:** 262
+**Schemas:** 265
 
 ## Schemas
 
@@ -244,6 +244,9 @@
 | assertion | `https://schemas.0xhoneyjar.com/loa-hounfour/8.7.0/assertion` | [assertion.schema.json](assertion.schema.json) |
 | phase-completion-envelope-tier1 | `https://schemas.0xhoneyjar.com/loa-hounfour/8.7.0/phase-completion-envelope-tier1` | [phase-completion-envelope-tier1.schema.json](phase-completion-envelope-tier1.schema.json) |
 | phase-completion-envelope | `https://schemas.0xhoneyjar.com/loa-hounfour/8.7.0/phase-completion-envelope` | [phase-completion-envelope.schema.json](phase-completion-envelope.schema.json) |
+| span-move | `https://schemas.0xhoneyjar.com/loa-hounfour/8.7.0/span-move` | [span-move.schema.json](span-move.schema.json) |
+| gate-token | `https://schemas.0xhoneyjar.com/loa-hounfour/8.7.0/gate-token` | [gate-token.schema.json](gate-token.schema.json) |
+| run-receipt | `https://schemas.0xhoneyjar.com/loa-hounfour/8.7.0/run-receipt` | [run-receipt.schema.json](run-receipt.schema.json) |
 | pulse-kind | `https://schemas.0xhoneyjar.com/loa-hounfour/8.7.0/pulse-kind` | [pulse-kind.schema.json](pulse-kind.schema.json) |
 | oracle-digest | `https://schemas.0xhoneyjar.com/loa-hounfour/8.7.0/oracle-digest` | [oracle-digest.schema.json](oracle-digest.schema.json) |
 | model-call-circuit-breaker-state | `https://schemas.0xhoneyjar.com/loa-hounfour/8.7.0/model-call-circuit-breaker-state` | [model-call-circuit-breaker-state.schema.json](model-call-circuit-breaker-state.schema.json) |

--- a/schemas/gate-token.schema.json
+++ b/schemas/gate-token.schema.json
@@ -1,0 +1,157 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.0xhoneyjar.com/loa-hounfour/8.7.0/gate-token",
+  "additionalProperties": false,
+  "x-cross-field-validated": true,
+  "x-crypto-bearing": true,
+  "x-chain-bearing": true,
+  "x-canonical-size-cap-bytes": 4096,
+  "description": "Ed25519-signed Legba gate token — the key between gates. Crypto-bearing + chain-bearing (prev_token_hash) + canonical-size-capped. Cycle-1 transport: embedded at the handoff envelope's `verdict.gate_token` (schema-legal — the envelope verdict object is construct-shaped); first-class envelope field at construct-handoff v1.2 in the turnstile rung.",
+  "type": "object",
+  "required": [
+    "token_kind",
+    "contract_version",
+    "run_id",
+    "gate_index",
+    "wave_number",
+    "prev_token_hash",
+    "span_log_head",
+    "span_move_count",
+    "artifact_hashes",
+    "verdict",
+    "checks",
+    "replay_seed",
+    "gatekeeper_key_id",
+    "key_version",
+    "ts",
+    "signature"
+  ],
+  "properties": {
+    "token_kind": {
+      "description": "Discriminator literal pinning the GateToken shape.",
+      "const": "legba_gate_token",
+      "type": "string"
+    },
+    "contract_version": {
+      "description": "Hounfour contract version. Pinned for the Legba cycle-1 ship line; the merge train assigns the final literal.",
+      "const": "8.8.0",
+      "type": "string"
+    },
+    "run_id": {
+      "minLength": 1,
+      "description": "Composition run identifier. Forged/replayed-token defense binds signature verification to run_id + gate_index + wave_number.",
+      "type": "string"
+    },
+    "gate_index": {
+      "minimum": 0,
+      "description": "Zero-based gate position (gate N closes span N).",
+      "type": "integer"
+    },
+    "wave_number": {
+      "minimum": 0,
+      "description": "Wave ordinal within a DAG fan-out segment (LG-9). Serial execution uses 0. A token is issued only when its whole wave has drained.",
+      "type": "integer"
+    },
+    "prev_token_hash": {
+      "pattern": "^sha256:[A-Fa-f0-9]{64}$",
+      "description": "sha256:<64-hex> of the previous token's canonical form; gate 0 anchors the chain with the genesis literal (LG-3b — the run receipt binds the anchor so verifiers agree on the first link).",
+      "type": "string"
+    },
+    "span_log_head": {
+      "pattern": "^[A-Fa-f0-9]{64}$",
+      "description": "The closed span's final record_hash. The gate replays the span chain and MUST recompute this head (check `chain`).",
+      "type": "string"
+    },
+    "span_move_count": {
+      "minimum": 0,
+      "description": "Move count of the closed span (cheap census check).",
+      "type": "integer"
+    },
+    "artifact_hashes": {
+      "description": "Content-addressed ids of the claimed handover objects (handoff envelope ids). Phantom artifacts fail check `cas_complete`.",
+      "type": "array",
+      "items": {
+        "pattern": "^sha256:[A-Fa-f0-9]{64}$",
+        "type": "string"
+      }
+    },
+    "verdict": {
+      "description": "Gate verdict. Only `pass` opens the next span; `fail` is terminal and provable (the refusal enters the chain and the receipt closes blocked_at_gate_N).",
+      "anyOf": [
+        {
+          "const": "pass",
+          "type": "string"
+        },
+        {
+          "const": "fail",
+          "type": "string"
+        }
+      ]
+    },
+    "checks": {
+      "additionalProperties": false,
+      "description": "Named results of the four deterministic gate checks.",
+      "type": "object",
+      "required": [
+        "chain",
+        "cas_complete",
+        "replay_sample",
+        "artifact_shape"
+      ],
+      "properties": {
+        "chain": {
+          "type": "boolean"
+        },
+        "cas_complete": {
+          "type": "boolean"
+        },
+        "replay_sample": {
+          "description": "`degraded` = ≥3 environment-divergence downgrades drawn in one gate (loud, audited; visible to turnstile + receipt).",
+          "anyOf": [
+            {
+              "const": "pass",
+              "type": "string"
+            },
+            {
+              "const": "fail",
+              "type": "string"
+            },
+            {
+              "const": "degraded",
+              "type": "string"
+            }
+          ]
+        },
+        "artifact_shape": {
+          "type": "boolean"
+        }
+      }
+    },
+    "replay_seed": {
+      "pattern": "^[A-Fa-f0-9]{64}$",
+      "description": "sha256(span_log_head || gatekeeper_sig(span_log_head)) — the worker cannot predict the sample (it cannot compute the gatekeeper's signature); any verifier reproduces it from the token (LT-2). Kept explicit for audit readability.",
+      "type": "string"
+    },
+    "gatekeeper_key_id": {
+      "pattern": "^[A-Fa-f0-9]{64}$",
+      "description": "Derived sha256 hex (bare form) of `gatekeeper_id || \":\" || key_version` — the hounfour signer-key-id derivation, verified by the LOCAL builtin (LT-1). Keys resolve through the loa trust-store, never bare manifest publication.",
+      "type": "string"
+    },
+    "key_version": {
+      "minimum": 1,
+      "description": "Gatekeeper key version (1-indexed). Mid-run rotation creates a named activation boundary; the receipt binds the key set.",
+      "type": "integer"
+    },
+    "ts": {
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?Z$",
+      "description": "ISO 8601 UTC token issuance time (Z suffix).",
+      "type": "string"
+    },
+    "signature": {
+      "pattern": "^ed25519:[A-Za-z0-9_-]{86}$",
+      "description": "Ed25519 signature (unpadded base64url, 86 chars after the \"ed25519:\" prefix) over the RFC 8785 canonical JSON of all-other-fields. Hounfour does NOT verify; consumer-side verification per NF-1.",
+      "type": "string"
+    }
+  },
+  "$comment": "contract_version=8.7.0, min_supported=6.0.0"
+}

--- a/schemas/index.json
+++ b/schemas/index.json
@@ -1420,6 +1420,24 @@
       "description": "Cluster-wrapped Tier-2 phase-completion envelope. Wraps Tier-1 (PhaseCompletionEnvelopeTier1Schema) for cluster-side ingestion with cluster_signature + signer_key_id (sha256-derived) + prev_envelope_hash chain link. Crypto-bearing + chain-bearing + canonical-size-capped at 4 KB (NFR-4)."
     },
     {
+      "name": "span-move",
+      "$id": "https://schemas.0xhoneyjar.com/loa-hounfour/8.7.0/span-move",
+      "file": "span-move.schema.json",
+      "description": "One hash-chained move in a Legba span log. Chain-bearing (prev_hash/record_hash intra-span chain), CAS-referencing (input/output hashes), canonical-size-capped at 4 KB. Not crypto-bearing: moves are not individually signed — the gate token signs the span head (GateToken)."
+    },
+    {
+      "name": "gate-token",
+      "$id": "https://schemas.0xhoneyjar.com/loa-hounfour/8.7.0/gate-token",
+      "file": "gate-token.schema.json",
+      "description": "Ed25519-signed Legba gate token — the key between gates. Crypto-bearing + chain-bearing (prev_token_hash) + canonical-size-capped. Cycle-1 transport: embedded at the handoff envelope's `verdict.gate_token` (schema-legal — the envelope verdict object is construct-shaped); first-class envelope field at construct-handoff v1.2 in the turnstile rung."
+    },
+    {
+      "name": "run-receipt",
+      "$id": "https://schemas.0xhoneyjar.com/loa-hounfour/8.7.0/run-receipt",
+      "file": "run-receipt.schema.json",
+      "description": "Legba run receipt — the token-hash chain + receipt-bound key set compiled to one verifiable hash. Chain-bearing; not itself crypto-bearing (the tokens it sequences carry the signatures; external anchoring into the loa audit chain provides the tamper-evidence for the receipt itself)."
+    },
+    {
       "name": "pulse-kind",
       "$id": "https://schemas.0xhoneyjar.com/loa-hounfour/8.7.0/pulse-kind",
       "file": "pulse-kind.schema.json",

--- a/schemas/run-receipt.schema.json
+++ b/schemas/run-receipt.schema.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.0xhoneyjar.com/loa-hounfour/8.7.0/run-receipt",
+  "additionalProperties": false,
+  "x-cross-field-validated": true,
+  "x-chain-bearing": true,
+  "description": "Legba run receipt — the token-hash chain + receipt-bound key set compiled to one verifiable hash. Chain-bearing; not itself crypto-bearing (the tokens it sequences carry the signatures; external anchoring into the loa audit chain provides the tamper-evidence for the receipt itself).",
+  "type": "object",
+  "required": [
+    "receipt_kind",
+    "contract_version",
+    "run_id",
+    "genesis_anchor",
+    "token_hash_sequence",
+    "key_set",
+    "status",
+    "receipt_hash"
+  ],
+  "properties": {
+    "receipt_kind": {
+      "description": "Discriminator literal pinning the RunReceipt shape.",
+      "const": "legba_run_receipt",
+      "type": "string"
+    },
+    "contract_version": {
+      "description": "Hounfour contract version. Pinned for the Legba cycle-1 ship line; the merge train assigns the final literal.",
+      "const": "8.8.0",
+      "type": "string"
+    },
+    "run_id": {
+      "minLength": 1,
+      "description": "Composition run identifier the receipt closes.",
+      "type": "string"
+    },
+    "genesis_anchor": {
+      "description": "Pinned chain-root literal (the PCE genesis convention). Vectors cover it; implementations cannot diverge on the first link (LG-3b).",
+      "const": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      "type": "string"
+    },
+    "token_hash_sequence": {
+      "minItems": 1,
+      "description": "Ordered token hashes — (gate_index, wave_number) order (LR-3). The full chain, retained for auditability.",
+      "type": "array",
+      "items": {
+        "pattern": "^sha256:[A-Fa-f0-9]{64}$",
+        "type": "string"
+      }
+    },
+    "key_set": {
+      "minItems": 1,
+      "description": "The signing keys this run's tokens used. Receipt-bound (covered by receipt_hash): rotation mid-run appends an entry and creates a named activation boundary — tokens signed by a revoked version after the boundary fail verification.",
+      "type": "array",
+      "items": {
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "gatekeeper_key_id",
+          "key_version",
+          "pubkey"
+        ],
+        "properties": {
+          "gatekeeper_key_id": {
+            "pattern": "^[A-Fa-f0-9]{64}$",
+            "type": "string"
+          },
+          "key_version": {
+            "minimum": 1,
+            "type": "integer"
+          },
+          "pubkey": {
+            "minLength": 1,
+            "description": "Ed25519 public key (consumer-shaped encoding). MUST match the trust-store-resolved key for the key_id — bare manifest publication is NOT trusted (anti-substitution).",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "status": {
+      "description": "Terminal run status. A fail-token terminates the run as blocked_at_gate_N — provable refusal, not silent halt.",
+      "anyOf": [
+        {
+          "const": "passed",
+          "type": "string"
+        },
+        {
+          "pattern": "^blocked_at_gate_[0-9]+$",
+          "type": "string"
+        }
+      ]
+    },
+    "receipt_hash": {
+      "pattern": "^[A-Fa-f0-9]{64}$",
+      "description": "sha256 (bare hex) of the RFC 8785 canonical JSON of {genesis_anchor, token_hash_sequence, key_set, status} (LR-1). Anchored into the loa audit chain at run close (LR-4).",
+      "type": "string"
+    }
+  },
+  "$comment": "contract_version=8.7.0, min_supported=6.0.0"
+}

--- a/schemas/span-move.schema.json
+++ b/schemas/span-move.schema.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.0xhoneyjar.com/loa-hounfour/8.7.0/span-move",
+  "additionalProperties": false,
+  "x-cross-field-validated": true,
+  "x-chain-bearing": true,
+  "x-cas-reference": true,
+  "x-canonical-size-cap-bytes": 4096,
+  "description": "One hash-chained move in a Legba span log. Chain-bearing (prev_hash/record_hash intra-span chain), CAS-referencing (input/output hashes), canonical-size-capped at 4 KB. Not crypto-bearing: moves are not individually signed — the gate token signs the span head (GateToken).",
+  "type": "object",
+  "required": [
+    "move_kind",
+    "contract_version",
+    "run_id",
+    "span_index",
+    "seq",
+    "prev_hash",
+    "kind",
+    "determinism",
+    "input_hash",
+    "output_hash",
+    "ts",
+    "record_hash"
+  ],
+  "properties": {
+    "move_kind": {
+      "description": "Discriminator literal pinning the SpanMove shape.",
+      "const": "legba_span_move",
+      "type": "string"
+    },
+    "contract_version": {
+      "description": "Hounfour contract version. Pinned for the Legba cycle-1 ship line; the merge train assigns the final literal.",
+      "const": "8.8.0",
+      "type": "string"
+    },
+    "run_id": {
+      "minLength": 1,
+      "description": "Composition run identifier (consumer-shaped). Binds the move to one run; tokens and the receipt carry the same id.",
+      "type": "string"
+    },
+    "span_index": {
+      "minimum": 0,
+      "description": "Zero-based segment index within the run.",
+      "type": "integer"
+    },
+    "seq": {
+      "minimum": 0,
+      "description": "Strictly monotonic move sequence within the span (LM-1). Gaps and repeats are chain violations.",
+      "type": "integer"
+    },
+    "prev_hash": {
+      "pattern": "^sha256:[A-Fa-f0-9]{64}$",
+      "description": "sha256:<64-hex> of the prior move's canonical form; the first move of a span carries the genesis anchor (LEGBA_GENESIS_ANCHOR). LM-2 verifies chain continuity.",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Event class: a tool invocation or a model emission (narration, judgment, verdict).",
+      "anyOf": [
+        {
+          "const": "tool",
+          "type": "string"
+        },
+        {
+          "const": "emission",
+          "type": "string"
+        }
+      ]
+    },
+    "determinism": {
+      "description": "Verification regime (LG-5). `re_executable` REQUIRES the tool to be content-recording allowlisted (replay needs retention); unlisted and nondeterministic tools are `attestable` by construction. Misclassification is the substrate's main integrity lie — the determinism manifest lint owns it.",
+      "anyOf": [
+        {
+          "const": "re_executable",
+          "type": "string"
+        },
+        {
+          "const": "attestable",
+          "type": "string"
+        }
+      ]
+    },
+    "tool": {
+      "minLength": 1,
+      "description": "Tool name for kind=tool (per the determinism manifest).",
+      "type": "string"
+    },
+    "label": {
+      "minLength": 1,
+      "description": "Emission label for kind=emission.",
+      "type": "string"
+    },
+    "input_hash": {
+      "pattern": "^[A-Fa-f0-9]{64}$",
+      "description": "Bare 64-hex sha256 over the canonical input bytes (composition rule in the schema header). CAS reference (`x-cas-reference`).",
+      "type": "string"
+    },
+    "output_hash": {
+      "pattern": "^[A-Fa-f0-9]{64}$",
+      "description": "Bare 64-hex sha256 over the canonical output bytes. CAS reference; re-execution divergence on an allowlisted re_executable move is a machine-detectable fraud proof (LG-4).",
+      "type": "string"
+    },
+    "env_fingerprint": {
+      "pattern": "^[A-Fa-f0-9]{64}$",
+      "description": "Bare 64-hex sha256 of the tool version + environment manifest (LG-4b). REQUIRED when determinism=re_executable (LM-4); replay under a divergent environment downgrades to attestable for that challenge — never false fraud.",
+      "type": "string"
+    },
+    "ts": {
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?Z$",
+      "description": "ISO 8601 UTC, microsecond precision, Z suffix (no offset form) — format pinned because ts participates in the canonical bytes.",
+      "type": "string"
+    },
+    "record_hash": {
+      "pattern": "^[A-Fa-f0-9]{64}$",
+      "description": "Bare 64-hex sha256 of the RFC 8785 canonical JSON of this record with the record_hash key ABSENT (LM-3). The span head is the final move's record_hash.",
+      "type": "string"
+    }
+  },
+  "$comment": "contract_version=8.7.0, min_supported=6.0.0"
+}

--- a/scripts/check-class-policy-boundary.ts
+++ b/scripts/check-class-policy-boundary.ts
@@ -107,6 +107,7 @@ export const RULE_4_CRYPTO_BEARING_NAMES = [
   // v8.6.0 PR-A3.4 — FR-B2 PhaseCompletionEnvelope (Tier-1 + Tier-2).
   'PhaseCompletionEnvelopeTier1Schema',
   'PhaseCompletionEnvelopeSchema',
+  'GateTokenSchema',
   // v8.6.0 PR-A3.6 — FR-B9 PlanSignoffEnvelope (x-crypto-bearing).
   'PlanSignoffEnvelopeSchema',
   // v8.6.0 PR-A3.7 — FR-A1 Challenge layer (x-crypto-bearing).

--- a/scripts/generate-schemas.ts
+++ b/scripts/generate-schemas.ts
@@ -206,6 +206,10 @@ import {
 import {
   PhaseCompletionEnvelopeSchema,
 } from '../src/integrity/phase-completion-envelope.js';
+// Legba substrate schemas (cycle 1)
+import { SpanMoveSchema } from '../src/integrity/legba-span-move.js';
+import { GateTokenSchema } from '../src/integrity/legba-gate-token.js';
+import { RunReceiptSchema } from '../src/integrity/legba-run-receipt.js';
 // v8.6.0 PR-A3.5 — FR-B3..B8 Operations cluster
 import {
   OracleDigestSchema,
@@ -574,6 +578,10 @@ export const SCHEMAS = [
   // v8.6.0 PR-A3.4 — FR-B2 PhaseCompletionEnvelope (Tier-1 + Tier-2)
   { name: 'phase-completion-envelope-tier1', schema: PhaseCompletionEnvelopeTier1Schema },
   { name: 'phase-completion-envelope', schema: PhaseCompletionEnvelopeSchema },
+  // Legba substrate schemas (cycle 1)
+  { name: 'span-move', schema: SpanMoveSchema },
+  { name: 'gate-token', schema: GateTokenSchema },
+  { name: 'run-receipt', schema: RunReceiptSchema },
   // v8.6.0 PR-A3.5 — FR-B3..B8 Operations cluster
   { name: 'pulse-kind', schema: PulseKindSchema },
   { name: 'oracle-digest', schema: OracleDigestSchema },

--- a/src/integrity/index.ts
+++ b/src/integrity/index.ts
@@ -96,3 +96,21 @@ export {
   SHA256_HEX_PATTERN,
   SHA256_HEX_BARE_PATTERN,
 } from './sha256-pattern.js';
+
+// Legba substrate schemas (cycle 1 — loa-freeside legba-substrate ladder).
+// SpanMove (chain-bearing), GateToken (crypto + chain-bearing), RunReceipt
+// (chain-bearing). Cross-field invariants live in constraints/<Schema>.constraints.json;
+// hand-written cross-field validators + registry wiring are a follow-up (post-ratification).
+export {
+  SpanMoveSchema,
+  LEGBA_GENESIS_ANCHOR,
+  type SpanMove,
+} from './legba-span-move.js';
+export {
+  GateTokenSchema,
+  type GateToken,
+} from './legba-gate-token.js';
+export {
+  RunReceiptSchema,
+  type RunReceipt,
+} from './legba-run-receipt.js';

--- a/src/integrity/legba-gate-token.ts
+++ b/src/integrity/legba-gate-token.ts
@@ -1,0 +1,170 @@
+/**
+ * `GateTokenSchema` — the ed25519-signed key between Legba gates
+ * (Legba ladder cycle 1; loa-freeside PRD G-1, SDD §3.2).
+ *
+ * Spans propose, gates validate, tokens carry custody. A span with index
+ * > 0 MUST refuse to open without a cryptographically valid token from
+ * gate index-1 of the same run (LG-3, the turnstile). Tokens chain via
+ * `prev_token_hash`; the run receipt is the hash of the token-hash
+ * sequence.
+ *
+ * **Turnstile predicate (split form — serial path must work)**: across
+ * segments, `gate_index == next_span_index - 1` with `wave_number` 0;
+ * within a DAG fan-out segment, wave advancement is
+ * `wave_number > prior.wave_number` at the same `gate_index` (LG-9 —
+ * tokens are wave-level under Kahn-wave parallel fan-out, issued when a
+ * whole wave drains, never per-item). Only `verdict: "pass"` opens a
+ * span; a fail-token is TERMINAL (receipt closes `blocked_at_gate_N`) —
+ * provable refusal beats a silent halt.
+ *
+ * **Schema-level invariants** (constraint file
+ * `constraints/GateToken.constraints.json`):
+ *   - `gatekeeper_key_id` = sha256(gatekeeper_id || ':' || key_version)
+ *     (LT-1, LOCAL `signer_key_id_matches_derivation` pattern reuse).
+ *   - `replay_seed` = sha256(span_log_head || gatekeeper signature over
+ *     span_log_head) (LT-2, runtime-deferred) — unpredictable to the
+ *     worker, reproducible by any verifier holding the token.
+ *   - `prev_token_hash` chain validity; genesis anchor at gate 0
+ *     (LT-3, library; LG-3b).
+ *   - Ed25519 `signature` over the RFC 8785 canonical JSON of
+ *     all-other-fields (LT-4, runtime-deferred; consumer-side
+ *     verification per hounfour NF-1 posture).
+ *
+ * @since Legba cycle 1
+ */
+import { Type, type Static } from '@sinclair/typebox';
+import { ED25519_SIGNATURE_PATTERN } from '../governance/signature-envelope.js';
+import { ISO8601_UTC_PATTERN } from '../utilities/iso8601-utc-pattern.js';
+import { SHA256_HEX_PATTERN, SHA256_HEX_BARE_PATTERN } from './sha256-pattern.js';
+
+export const GateTokenSchema = Type.Object(
+  {
+    token_kind: Type.Literal('legba_gate_token', {
+      description: 'Discriminator literal pinning the GateToken shape.',
+    }),
+    contract_version: Type.Literal('8.8.0', {
+      description:
+        'Hounfour contract version. Pinned for the Legba cycle-1 ship ' +
+        'line; the merge train assigns the final literal.',
+    }),
+    run_id: Type.String({
+      minLength: 1,
+      description:
+        'Composition run identifier. Forged/replayed-token defense binds ' +
+        'signature verification to run_id + gate_index + wave_number.',
+    }),
+    gate_index: Type.Integer({
+      minimum: 0,
+      description: 'Zero-based gate position (gate N closes span N).',
+    }),
+    wave_number: Type.Integer({
+      minimum: 0,
+      description:
+        'Wave ordinal within a DAG fan-out segment (LG-9). Serial ' +
+        'execution uses 0. A token is issued only when its whole wave ' +
+        'has drained.',
+    }),
+    prev_token_hash: Type.String({
+      pattern: SHA256_HEX_PATTERN,
+      description:
+        'sha256:<64-hex> of the previous token\'s canonical form; gate 0 ' +
+        'anchors the chain with the genesis literal (LG-3b — the run ' +
+        'receipt binds the anchor so verifiers agree on the first link).',
+    }),
+    span_log_head: Type.String({
+      pattern: SHA256_HEX_BARE_PATTERN,
+      description:
+        'The closed span\'s final record_hash. The gate replays the span ' +
+        'chain and MUST recompute this head (check `chain`).',
+    }),
+    span_move_count: Type.Integer({
+      minimum: 0,
+      description: 'Move count of the closed span (cheap census check).',
+    }),
+    artifact_hashes: Type.Array(
+      Type.String({ pattern: SHA256_HEX_PATTERN }),
+      {
+        description:
+          'Content-addressed ids of the claimed handover objects ' +
+          '(handoff envelope ids). Phantom artifacts fail check ' +
+          '`cas_complete`.',
+      },
+    ),
+    verdict: Type.Union([Type.Literal('pass'), Type.Literal('fail')], {
+      description:
+        'Gate verdict. Only `pass` opens the next span; `fail` is ' +
+        'terminal and provable (the refusal enters the chain and the ' +
+        'receipt closes blocked_at_gate_N).',
+    }),
+    checks: Type.Object(
+      {
+        chain: Type.Boolean(),
+        cas_complete: Type.Boolean(),
+        replay_sample: Type.Union(
+          [Type.Literal('pass'), Type.Literal('fail'), Type.Literal('degraded')],
+          {
+            description:
+              '`degraded` = ≥3 environment-divergence downgrades drawn in ' +
+              'one gate (loud, audited; visible to turnstile + receipt).',
+          },
+        ),
+        artifact_shape: Type.Boolean(),
+      },
+      {
+        additionalProperties: false,
+        description: 'Named results of the four deterministic gate checks.',
+      },
+    ),
+    replay_seed: Type.String({
+      pattern: SHA256_HEX_BARE_PATTERN,
+      description:
+        'sha256(span_log_head || gatekeeper_sig(span_log_head)) — the ' +
+        'worker cannot predict the sample (it cannot compute the ' +
+        'gatekeeper\'s signature); any verifier reproduces it from the ' +
+        'token (LT-2). Kept explicit for audit readability.',
+    }),
+    gatekeeper_key_id: Type.String({
+      pattern: SHA256_HEX_BARE_PATTERN,
+      description:
+        'Derived sha256 hex (bare form) of `gatekeeper_id || ":" || ' +
+        'key_version` — the hounfour signer-key-id derivation, verified ' +
+        'by the LOCAL builtin (LT-1). Keys resolve through the loa ' +
+        'trust-store, never bare manifest publication.',
+    }),
+    key_version: Type.Integer({
+      minimum: 1,
+      description:
+        'Gatekeeper key version (1-indexed). Mid-run rotation creates a ' +
+        'named activation boundary; the receipt binds the key set.',
+    }),
+    ts: Type.String({
+      pattern: ISO8601_UTC_PATTERN,
+      description: 'ISO 8601 UTC token issuance time (Z suffix).',
+    }),
+    signature: Type.String({
+      pattern: ED25519_SIGNATURE_PATTERN,
+      description:
+        'Ed25519 signature (unpadded base64url, 86 chars after the ' +
+        '"ed25519:" prefix) over the RFC 8785 canonical JSON of ' +
+        'all-other-fields. Hounfour does NOT verify; consumer-side ' +
+        'verification per NF-1.',
+    }),
+  },
+  {
+    $id: 'GateToken',
+    additionalProperties: false,
+    'x-cross-field-validated': true,
+    'x-crypto-bearing': true,
+    'x-chain-bearing': true,
+    'x-canonical-size-cap-bytes': 4096,
+    description:
+      'Ed25519-signed Legba gate token — the key between gates. ' +
+      'Crypto-bearing + chain-bearing (prev_token_hash) + ' +
+      'canonical-size-capped. Cycle-1 transport: embedded at the handoff ' +
+      'envelope\'s `verdict.gate_token` (schema-legal — the envelope ' +
+      'verdict object is construct-shaped); first-class envelope field ' +
+      'at construct-handoff v1.2 in the turnstile rung.',
+  },
+);
+
+export type GateToken = Static<typeof GateTokenSchema>;

--- a/src/integrity/legba-run-receipt.ts
+++ b/src/integrity/legba-run-receipt.ts
@@ -1,0 +1,119 @@
+/**
+ * `RunReceiptSchema` — a Legba run compiled to one verifiable hash
+ * (Legba ladder cycle 1; loa-freeside PRD G-1, SDD §3.3).
+ *
+ * "Compiled down and verifiable": a multi-hour, thousand-token,
+ * irreproducible agentic run reduces to a chain of gate-token hashes and
+ * one receipt hash a third party can verify with public keys alone —
+ * the strongest verifiability available over nondeterministic workers.
+ *
+ * **Schema-level invariants** (constraint file
+ * `constraints/RunReceipt.constraints.json`):
+ *   - `receipt_hash` = sha256 of the RFC 8785 canonical JSON of
+ *     `{genesis_anchor, token_hash_sequence, key_set, status}` — the
+ *     receipt hash COVERS the key set, binding signer identity; a
+ *     mutated key_set breaks the receipt (LR-1, library).
+ *   - `genesis_anchor` is the pinned literal — no implementation-
+ *     divergent chain roots (LR-2, library; LG-3b).
+ *   - `token_hash_sequence` is ordered by (gate_index, wave_number)
+ *     (LR-3, library).
+ *   - External anchoring: at run close the receipt_hash is emitted into
+ *     the loa audit chain via audit_emit — retroactive forgery must
+ *     rewrite the independent hash-chained, signed audit log too
+ *     (LR-4, runtime-deferred; consumer policy).
+ *
+ * @since Legba cycle 1
+ */
+import { Type, type Static } from '@sinclair/typebox';
+import { SHA256_HEX_PATTERN, SHA256_HEX_BARE_PATTERN } from './sha256-pattern.js';
+
+export const RunReceiptSchema = Type.Object(
+  {
+    receipt_kind: Type.Literal('legba_run_receipt', {
+      description: 'Discriminator literal pinning the RunReceipt shape.',
+    }),
+    contract_version: Type.Literal('8.8.0', {
+      description:
+        'Hounfour contract version. Pinned for the Legba cycle-1 ship ' +
+        'line; the merge train assigns the final literal.',
+    }),
+    run_id: Type.String({
+      minLength: 1,
+      description: 'Composition run identifier the receipt closes.',
+    }),
+    genesis_anchor: Type.Literal(
+      'sha256:0000000000000000000000000000000000000000000000000000000000000000',
+      {
+        description:
+          'Pinned chain-root literal (the PCE genesis convention). ' +
+          'Vectors cover it; implementations cannot diverge on the ' +
+          'first link (LG-3b).',
+      },
+    ),
+    token_hash_sequence: Type.Array(
+      Type.String({ pattern: SHA256_HEX_PATTERN }),
+      {
+        minItems: 1,
+        description:
+          'Ordered token hashes — (gate_index, wave_number) order ' +
+          '(LR-3). The full chain, retained for auditability.',
+      },
+    ),
+    key_set: Type.Array(
+      Type.Object(
+        {
+          gatekeeper_key_id: Type.String({ pattern: SHA256_HEX_BARE_PATTERN }),
+          key_version: Type.Integer({ minimum: 1 }),
+          pubkey: Type.String({
+            minLength: 1,
+            description:
+              'Ed25519 public key (consumer-shaped encoding). MUST match ' +
+              'the trust-store-resolved key for the key_id — bare ' +
+              'manifest publication is NOT trusted (anti-substitution).',
+          }),
+        },
+        { additionalProperties: false },
+      ),
+      {
+        minItems: 1,
+        description:
+          'The signing keys this run\'s tokens used. Receipt-bound ' +
+          '(covered by receipt_hash): rotation mid-run appends an entry ' +
+          'and creates a named activation boundary — tokens signed by a ' +
+          'revoked version after the boundary fail verification.',
+      },
+    ),
+    status: Type.Union(
+      [
+        Type.Literal('passed'),
+        Type.String({ pattern: '^blocked_at_gate_[0-9]+$' }),
+      ],
+      {
+        description:
+          'Terminal run status. A fail-token terminates the run as ' +
+          'blocked_at_gate_N — provable refusal, not silent halt.',
+      },
+    ),
+    receipt_hash: Type.String({
+      pattern: SHA256_HEX_BARE_PATTERN,
+      description:
+        'sha256 (bare hex) of the RFC 8785 canonical JSON of ' +
+        '{genesis_anchor, token_hash_sequence, key_set, status} (LR-1). ' +
+        'Anchored into the loa audit chain at run close (LR-4).',
+    }),
+  },
+  {
+    $id: 'RunReceipt',
+    additionalProperties: false,
+    'x-cross-field-validated': true,
+    'x-chain-bearing': true,
+    description:
+      'Legba run receipt — the token-hash chain + receipt-bound key set ' +
+      'compiled to one verifiable hash. Chain-bearing; not itself ' +
+      'crypto-bearing (the tokens it sequences carry the signatures; ' +
+      'external anchoring into the loa audit chain provides the ' +
+      'tamper-evidence for the receipt itself).',
+  },
+);
+
+export type RunReceipt = Static<typeof RunReceiptSchema>;

--- a/src/integrity/legba-span-move.ts
+++ b/src/integrity/legba-span-move.ts
@@ -1,0 +1,156 @@
+/**
+ * `SpanMoveSchema` — one event in a Legba span's hash-chained move log
+ * (Legba ladder cycle 1; loa-freeside PRD G-1, SDD §3.1).
+ *
+ * A span is the nondeterministic agent work between two gates. Every
+ * state mutation appends exactly one chained move record (LG-1); flipping
+ * any byte of history changes the span head (LG-2). Moves are either
+ * `re_executable` (allowlisted tool calls — input/output content-addressed
+ * and replayable from CAS) or `attestable` (model emissions and hash-only
+ * tools — provably *said*, never provably *correct*).
+ *
+ * **Schema-level invariants** (constraint file
+ * `constraints/SpanMove.constraints.json`):
+ *   - `seq` strictly monotonic per span (LM-1, library).
+ *   - `prev_hash` MUST equal the prior move's `record_hash`; the first
+ *     move uses the genesis anchor (LM-2, library).
+ *   - `record_hash` = sha256 of the RFC 8785 canonical JSON of the record
+ *     with the `record_hash` key ABSENT — omitted before canonicalization,
+ *     not empty or null (LM-3, library).
+ *   - `env_fingerprint` REQUIRED iff `determinism` is `re_executable`
+ *     (LM-4, library; LG-4b — environment divergence at replay downgrades
+ *     the challenge to attestable, never reports fraud).
+ *   - Canonical form ≤ 4096 bytes (LM-5, LOCAL `canonical_size_cap`);
+ *     producers MUST refuse loudly at record time (`LEGBA_MOVE_TOO_LARGE`),
+ *     never truncate.
+ *
+ * **Canonical byte composition for `input_hash`/`output_hash`** (one rule,
+ * cross-implementation): file inputs hash raw file bytes; structured tool
+ * args hash the RFC 8785 canonical JSON bytes of the args object;
+ * multi-input moves hash `sha256(JCS(sorted hash list))`.
+ *
+ * @since Legba cycle 1 (vectors gate the contract_version bump per LG-8)
+ */
+import { Type, type Static } from '@sinclair/typebox';
+import { ISO8601_UTC_PATTERN } from '../utilities/iso8601-utc-pattern.js';
+import { SHA256_HEX_PATTERN, SHA256_HEX_BARE_PATTERN } from './sha256-pattern.js';
+
+/** Genesis anchor literal shared by span chains and the token chain (LG-3b). */
+export const LEGBA_GENESIS_ANCHOR =
+  'sha256:0000000000000000000000000000000000000000000000000000000000000000' as const;
+
+export const SpanMoveSchema = Type.Object(
+  {
+    move_kind: Type.Literal('legba_span_move', {
+      description: 'Discriminator literal pinning the SpanMove shape.',
+    }),
+    contract_version: Type.Literal('8.8.0', {
+      description:
+        'Hounfour contract version. Pinned for the Legba cycle-1 ship ' +
+        'line; the merge train assigns the final literal.',
+    }),
+    run_id: Type.String({
+      minLength: 1,
+      description:
+        'Composition run identifier (consumer-shaped). Binds the move to ' +
+        'one run; tokens and the receipt carry the same id.',
+    }),
+    span_index: Type.Integer({
+      minimum: 0,
+      description: 'Zero-based segment index within the run.',
+    }),
+    seq: Type.Integer({
+      minimum: 0,
+      description:
+        'Strictly monotonic move sequence within the span (LM-1). Gaps ' +
+        'and repeats are chain violations.',
+    }),
+    prev_hash: Type.String({
+      pattern: SHA256_HEX_PATTERN,
+      description:
+        'sha256:<64-hex> of the prior move\'s canonical form; the first ' +
+        'move of a span carries the genesis anchor ' +
+        '(LEGBA_GENESIS_ANCHOR). LM-2 verifies chain continuity.',
+    }),
+    kind: Type.Union([Type.Literal('tool'), Type.Literal('emission')], {
+      description:
+        'Event class: a tool invocation or a model emission (narration, ' +
+        'judgment, verdict).',
+    }),
+    determinism: Type.Union(
+      [Type.Literal('re_executable'), Type.Literal('attestable')],
+      {
+        description:
+          'Verification regime (LG-5). `re_executable` REQUIRES the tool ' +
+          'to be content-recording allowlisted (replay needs retention); ' +
+          'unlisted and nondeterministic tools are `attestable` by ' +
+          'construction. Misclassification is the substrate\'s main ' +
+          'integrity lie — the determinism manifest lint owns it.',
+      },
+    ),
+    tool: Type.Optional(
+      Type.String({
+        minLength: 1,
+        description: 'Tool name for kind=tool (per the determinism manifest).',
+      }),
+    ),
+    label: Type.Optional(
+      Type.String({
+        minLength: 1,
+        description: 'Emission label for kind=emission.',
+      }),
+    ),
+    input_hash: Type.String({
+      pattern: SHA256_HEX_BARE_PATTERN,
+      description:
+        'Bare 64-hex sha256 over the canonical input bytes (composition ' +
+        'rule in the schema header). CAS reference (`x-cas-reference`).',
+    }),
+    output_hash: Type.String({
+      pattern: SHA256_HEX_BARE_PATTERN,
+      description:
+        'Bare 64-hex sha256 over the canonical output bytes. CAS ' +
+        'reference; re-execution divergence on an allowlisted ' +
+        're_executable move is a machine-detectable fraud proof (LG-4).',
+    }),
+    env_fingerprint: Type.Optional(
+      Type.String({
+        pattern: SHA256_HEX_BARE_PATTERN,
+        description:
+          'Bare 64-hex sha256 of the tool version + environment manifest ' +
+          '(LG-4b). REQUIRED when determinism=re_executable (LM-4); ' +
+          'replay under a divergent environment downgrades to attestable ' +
+          'for that challenge — never false fraud.',
+      }),
+    ),
+    ts: Type.String({
+      pattern: ISO8601_UTC_PATTERN,
+      description:
+        'ISO 8601 UTC, microsecond precision, Z suffix (no offset form) — ' +
+        'format pinned because ts participates in the canonical bytes.',
+    }),
+    record_hash: Type.String({
+      pattern: SHA256_HEX_BARE_PATTERN,
+      description:
+        'Bare 64-hex sha256 of the RFC 8785 canonical JSON of this record ' +
+        'with the record_hash key ABSENT (LM-3). The span head is the ' +
+        'final move\'s record_hash.',
+    }),
+  },
+  {
+    $id: 'SpanMove',
+    additionalProperties: false,
+    'x-cross-field-validated': true,
+    'x-chain-bearing': true,
+    'x-cas-reference': true,
+    'x-canonical-size-cap-bytes': 4096,
+    description:
+      'One hash-chained move in a Legba span log. Chain-bearing ' +
+      '(prev_hash/record_hash intra-span chain), CAS-referencing ' +
+      '(input/output hashes), canonical-size-capped at 4 KB. Not ' +
+      'crypto-bearing: moves are not individually signed — the gate ' +
+      'token signs the span head (GateToken).',
+  },
+);
+
+export type SpanMove = Static<typeof SpanMoveSchema>;

--- a/tests/constraints/origin.test.ts
+++ b/tests/constraints/origin.test.ts
@@ -25,7 +25,7 @@ describe('ConstraintOrigin', () => {
     const files = fs.readdirSync(CONSTRAINTS_DIR)
       .filter(f => f.endsWith('.constraints.json'));
 
-    expect(files.length).toBe(140);
+    expect(files.length).toBe(143);
 
     for (const file of files) {
       const content = JSON.parse(fs.readFileSync(path.join(CONSTRAINTS_DIR, file), 'utf8'));

--- a/tests/constraints/type-signature-migration.test.ts
+++ b/tests/constraints/type-signature-migration.test.ts
@@ -45,7 +45,7 @@ function isValidType(t: string): boolean {
 
 describe('type_signature migration (S2-T5)', () => {
   it('found constraint files', () => {
-    expect(allFiles.length).toBe(140);
+    expect(allFiles.length).toBe(143);
   });
 
   for (const { filename, data } of allFiles) {

--- a/tests/vectors/legba-schemas-vectors.test.ts
+++ b/tests/vectors/legba-schemas-vectors.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Vector-fixture conformance runner for the Legba substrate schemas
+ * (SpanMove, GateToken, RunReceipt — loa-freeside legba-substrate cycle 1).
+ *
+ * STRUCTURAL TIER ONLY. This runner exercises `Value.Check` (the structural
+ * layer) against the three bucket contract:
+ *
+ *   - `valid/*.json`            → PASS Value.Check (well-formed instances).
+ *   - `invalid/*.json`          → FAIL Value.Check (structural rejection:
+ *                                 missing discriminator, bad pattern, bad enum,
+ *                                 additionalProperties, non-literal genesis).
+ *   - `invalid-cross-field/*.json` → PASS Value.Check (structurally well-formed)
+ *                                 but carry a CONSTRAINT violation (seq gap,
+ *                                 record_hash drift, mutated key_set, predictable
+ *                                 seed, replayed run_id). The hand-written
+ *                                 cross-field validators that REJECT these at
+ *                                 validate() time are a post-ratification
+ *                                 follow-up; the corpus is staged here now so the
+ *                                 validator work has its fixtures ready. Until
+ *                                 then this runner asserts only that they are
+ *                                 structurally well-formed — the meaningful
+ *                                 partial guarantee (a cross-field fixture that
+ *                                 fails Value.Check is mis-bucketed).
+ *
+ * Each fixture may carry an optional `_comment` field, stripped before checking.
+ */
+import { describe, it, expect } from 'vitest';
+import { Value } from '@sinclair/typebox/value';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { SpanMoveSchema } from '../../src/integrity/legba-span-move.js';
+import { GateTokenSchema } from '../../src/integrity/legba-gate-token.js';
+import { RunReceiptSchema } from '../../src/integrity/legba-run-receipt.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function bucketRoot(schema: string, bucket: string): string {
+  return join(__dirname, '..', '..', 'vectors', schema, 'v8.8.0', bucket);
+}
+
+function load(schema: string, bucket: string, name: string): unknown {
+  const raw = JSON.parse(
+    readFileSync(join(bucketRoot(schema, bucket), name), 'utf8'),
+  ) as Record<string, unknown>;
+  const { _comment: _drop, ...data } = raw;
+  return data;
+}
+
+function names(schema: string, bucket: string): string[] {
+  const dir = bucketRoot(schema, bucket);
+  return existsSync(dir) ? readdirSync(dir).filter((f) => f.endsWith('.json')) : [];
+}
+
+const cases = [
+  { schema: 'SpanMove', tb: SpanMoveSchema },
+  { schema: 'GateToken', tb: GateTokenSchema },
+  { schema: 'RunReceipt', tb: RunReceiptSchema },
+] as const;
+
+for (const { schema, tb } of cases) {
+  describe(`${schema} vectors (structural tier)`, () => {
+    it('has at least one valid + one invalid + one invalid-cross-field fixture', () => {
+      expect(names(schema, 'valid').length).toBeGreaterThan(0);
+      expect(names(schema, 'invalid').length).toBeGreaterThan(0);
+      expect(names(schema, 'invalid-cross-field').length).toBeGreaterThan(0);
+    });
+
+    for (const name of names(schema, 'valid')) {
+      it(`valid/${name} passes Value.Check`, () => {
+        expect(Value.Check(tb, load(schema, 'valid', name))).toBe(true);
+      });
+    }
+
+    for (const name of names(schema, 'invalid')) {
+      it(`invalid/${name} fails Value.Check (structural)`, () => {
+        expect(Value.Check(tb, load(schema, 'invalid', name))).toBe(false);
+      });
+    }
+
+    for (const name of names(schema, 'invalid-cross-field')) {
+      it(`invalid-cross-field/${name} passes Value.Check (well-formed; cross-field reject pending validator)`, () => {
+        expect(Value.Check(tb, load(schema, 'invalid-cross-field', name))).toBe(true);
+      });
+    }
+  });
+}

--- a/tests/vectors/version-bump.test.ts
+++ b/tests/vectors/version-bump.test.ts
@@ -326,6 +326,7 @@ describe('version bump', () => {
     // ClusterRunSeries, InterSeriesScopingArtifact, SubscriptionPoolState,
     // RevocationList, MergeArtifact → 262. Stubs use Type.Never() so any
     // payload fails validation; the $id namespace is reserved.
-    expect(index.schemas).toHaveLength(262);
+    // legba-substrate cycle 1 adds 3: SpanMove, GateToken, RunReceipt → 265.
+    expect(index.schemas).toHaveLength(265);
   });
 });

--- a/vectors/GateToken/v8.8.0/invalid-cross-field/predictable-replay-seed.json
+++ b/vectors/GateToken/v8.8.0/invalid-cross-field/predictable-replay-seed.json
@@ -1,0 +1,26 @@
+{
+  "_comment": "LT-2: replay_seed equals span_log_head (worker-predictable; cross-field reject).",
+  "token_kind": "legba_gate_token",
+  "contract_version": "8.8.0",
+  "run_id": "vec-run",
+  "gate_index": 0,
+  "wave_number": 0,
+  "prev_token_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "span_log_head": "8bf3197745503554d778d51cebc0a733fdaec651d1c09b2d4a80df6e9a8dea4b",
+  "span_move_count": 2,
+  "artifact_hashes": [
+    "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+  ],
+  "verdict": "pass",
+  "checks": {
+    "chain": true,
+    "cas_complete": true,
+    "replay_sample": "pass",
+    "artifact_shape": true
+  },
+  "replay_seed": "8bf3197745503554d778d51cebc0a733fdaec651d1c09b2d4a80df6e9a8dea4b",
+  "gatekeeper_key_id": "2222222222222222222222222222222222222222222222222222222222222222",
+  "key_version": 1,
+  "ts": "2026-06-11T00:00:02.000000Z",
+  "signature": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+}

--- a/vectors/GateToken/v8.8.0/invalid-cross-field/replayed-wrong-run-id.json
+++ b/vectors/GateToken/v8.8.0/invalid-cross-field/replayed-wrong-run-id.json
@@ -1,0 +1,26 @@
+{
+  "_comment": "Token bound to a different run_id (schema-valid; replay-defense cross-field reject).",
+  "token_kind": "legba_gate_token",
+  "contract_version": "8.8.0",
+  "run_id": "other-run",
+  "gate_index": 0,
+  "wave_number": 0,
+  "prev_token_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "span_log_head": "8bf3197745503554d778d51cebc0a733fdaec651d1c09b2d4a80df6e9a8dea4b",
+  "span_move_count": 2,
+  "artifact_hashes": [
+    "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+  ],
+  "verdict": "pass",
+  "checks": {
+    "chain": true,
+    "cas_complete": true,
+    "replay_sample": "pass",
+    "artifact_shape": true
+  },
+  "replay_seed": "1111111111111111111111111111111111111111111111111111111111111111",
+  "gatekeeper_key_id": "2222222222222222222222222222222222222222222222222222222222222222",
+  "key_version": 1,
+  "ts": "2026-06-11T00:00:02.000000Z",
+  "signature": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+}

--- a/vectors/GateToken/v8.8.0/invalid/additional-property.json
+++ b/vectors/GateToken/v8.8.0/invalid/additional-property.json
@@ -1,0 +1,27 @@
+{
+  "_comment": "additionalProperties:false rejects the extra field — structural rejection.",
+  "token_kind": "legba_gate_token",
+  "contract_version": "8.8.0",
+  "run_id": "vec-run",
+  "gate_index": 0,
+  "wave_number": 0,
+  "prev_token_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "span_log_head": "8bf3197745503554d778d51cebc0a733fdaec651d1c09b2d4a80df6e9a8dea4b",
+  "span_move_count": 2,
+  "artifact_hashes": [
+    "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+  ],
+  "verdict": "pass",
+  "checks": {
+    "chain": true,
+    "cas_complete": true,
+    "replay_sample": "pass",
+    "artifact_shape": true
+  },
+  "replay_seed": "1111111111111111111111111111111111111111111111111111111111111111",
+  "gatekeeper_key_id": "2222222222222222222222222222222222222222222222222222222222222222",
+  "key_version": 1,
+  "ts": "2026-06-11T00:00:02.000000Z",
+  "signature": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+  "_extra": "x"
+}

--- a/vectors/GateToken/v8.8.0/invalid/bad-replay-sample-enum.json
+++ b/vectors/GateToken/v8.8.0/invalid/bad-replay-sample-enum.json
@@ -1,0 +1,26 @@
+{
+  "_comment": "checks.replay_sample not in {pass,fail,degraded} — structural rejection.",
+  "token_kind": "legba_gate_token",
+  "contract_version": "8.8.0",
+  "run_id": "vec-run",
+  "gate_index": 0,
+  "wave_number": 0,
+  "prev_token_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "span_log_head": "8bf3197745503554d778d51cebc0a733fdaec651d1c09b2d4a80df6e9a8dea4b",
+  "span_move_count": 2,
+  "artifact_hashes": [
+    "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+  ],
+  "verdict": "pass",
+  "checks": {
+    "chain": true,
+    "cas_complete": true,
+    "replay_sample": "ok",
+    "artifact_shape": true
+  },
+  "replay_seed": "1111111111111111111111111111111111111111111111111111111111111111",
+  "gatekeeper_key_id": "2222222222222222222222222222222222222222222222222222222222222222",
+  "key_version": 1,
+  "ts": "2026-06-11T00:00:02.000000Z",
+  "signature": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+}

--- a/vectors/GateToken/v8.8.0/invalid/forged-signature-shape.json
+++ b/vectors/GateToken/v8.8.0/invalid/forged-signature-shape.json
@@ -1,0 +1,26 @@
+{
+  "_comment": "signature fails ED25519 pattern — structural rejection (forgery).",
+  "token_kind": "legba_gate_token",
+  "contract_version": "8.8.0",
+  "run_id": "vec-run",
+  "gate_index": 0,
+  "wave_number": 0,
+  "prev_token_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "span_log_head": "8bf3197745503554d778d51cebc0a733fdaec651d1c09b2d4a80df6e9a8dea4b",
+  "span_move_count": 2,
+  "artifact_hashes": [
+    "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+  ],
+  "verdict": "pass",
+  "checks": {
+    "chain": true,
+    "cas_complete": true,
+    "replay_sample": "pass",
+    "artifact_shape": true
+  },
+  "replay_seed": "1111111111111111111111111111111111111111111111111111111111111111",
+  "gatekeeper_key_id": "2222222222222222222222222222222222222222222222222222222222222222",
+  "key_version": 1,
+  "ts": "2026-06-11T00:00:02.000000Z",
+  "signature": "ed25519:short"
+}

--- a/vectors/GateToken/v8.8.0/valid/fail-token-terminal.json
+++ b/vectors/GateToken/v8.8.0/valid/fail-token-terminal.json
@@ -1,0 +1,26 @@
+{
+  "_comment": "Fail-token is terminal (provable refusal); structurally valid.",
+  "token_kind": "legba_gate_token",
+  "contract_version": "8.8.0",
+  "run_id": "vec-run",
+  "gate_index": 0,
+  "wave_number": 0,
+  "prev_token_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "span_log_head": "8bf3197745503554d778d51cebc0a733fdaec651d1c09b2d4a80df6e9a8dea4b",
+  "span_move_count": 2,
+  "artifact_hashes": [
+    "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+  ],
+  "verdict": "fail",
+  "checks": {
+    "chain": false,
+    "cas_complete": true,
+    "replay_sample": "pass",
+    "artifact_shape": true
+  },
+  "replay_seed": "1111111111111111111111111111111111111111111111111111111111111111",
+  "gatekeeper_key_id": "2222222222222222222222222222222222222222222222222222222222222222",
+  "key_version": 1,
+  "ts": "2026-06-11T00:00:02.000000Z",
+  "signature": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+}

--- a/vectors/GateToken/v8.8.0/valid/pass-token-gate0-genesis.json
+++ b/vectors/GateToken/v8.8.0/valid/pass-token-gate0-genesis.json
@@ -1,0 +1,26 @@
+{
+  "_comment": "Gate-0 pass token; genesis prev_token_hash.",
+  "token_kind": "legba_gate_token",
+  "contract_version": "8.8.0",
+  "run_id": "vec-run",
+  "gate_index": 0,
+  "wave_number": 0,
+  "prev_token_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "span_log_head": "8bf3197745503554d778d51cebc0a733fdaec651d1c09b2d4a80df6e9a8dea4b",
+  "span_move_count": 2,
+  "artifact_hashes": [
+    "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+  ],
+  "verdict": "pass",
+  "checks": {
+    "chain": true,
+    "cas_complete": true,
+    "replay_sample": "pass",
+    "artifact_shape": true
+  },
+  "replay_seed": "1111111111111111111111111111111111111111111111111111111111111111",
+  "gatekeeper_key_id": "2222222222222222222222222222222222222222222222222222222222222222",
+  "key_version": 1,
+  "ts": "2026-06-11T00:00:02.000000Z",
+  "signature": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+}

--- a/vectors/GateToken/v8.8.0/valid/wave-level-token.json
+++ b/vectors/GateToken/v8.8.0/valid/wave-level-token.json
@@ -1,0 +1,26 @@
+{
+  "_comment": "LG-9 wave-level token (gate_index 1, wave 3).",
+  "token_kind": "legba_gate_token",
+  "contract_version": "8.8.0",
+  "run_id": "vec-run",
+  "gate_index": 1,
+  "wave_number": 3,
+  "prev_token_hash": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+  "span_log_head": "8bf3197745503554d778d51cebc0a733fdaec651d1c09b2d4a80df6e9a8dea4b",
+  "span_move_count": 2,
+  "artifact_hashes": [
+    "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+  ],
+  "verdict": "pass",
+  "checks": {
+    "chain": true,
+    "cas_complete": true,
+    "replay_sample": "pass",
+    "artifact_shape": true
+  },
+  "replay_seed": "1111111111111111111111111111111111111111111111111111111111111111",
+  "gatekeeper_key_id": "2222222222222222222222222222222222222222222222222222222222222222",
+  "key_version": 1,
+  "ts": "2026-06-11T00:00:02.000000Z",
+  "signature": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+}

--- a/vectors/RunReceipt/v8.8.0/invalid-cross-field/mutated-key-set.json
+++ b/vectors/RunReceipt/v8.8.0/invalid-cross-field/mutated-key-set.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "LR-1: key_set mutated, receipt_hash stale (schema-valid; cross-field signer-binding reject).",
+  "receipt_kind": "legba_run_receipt",
+  "contract_version": "8.8.0",
+  "run_id": "vec-run",
+  "genesis_anchor": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "token_hash_sequence": [
+    "sha256:7a5eacb885e422af7486518123c461f9f9dbd30c8ceedf0f8986285f909ec563"
+  ],
+  "key_set": [
+    {
+      "gatekeeper_key_id": "2222222222222222222222222222222222222222222222222222222222222222",
+      "key_version": 99,
+      "pubkey": "ed25519:KKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKK"
+    }
+  ],
+  "status": "passed",
+  "receipt_hash": "1321c46b407acabd5978b4738a44b80f647dbf1e6bcdd95ff45e5492c943f5ff"
+}

--- a/vectors/RunReceipt/v8.8.0/invalid/bad-status.json
+++ b/vectors/RunReceipt/v8.8.0/invalid/bad-status.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "status neither 'passed' nor blocked_at_gate_N — structural rejection.",
+  "receipt_kind": "legba_run_receipt",
+  "contract_version": "8.8.0",
+  "run_id": "vec-run",
+  "genesis_anchor": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "token_hash_sequence": [
+    "sha256:7a5eacb885e422af7486518123c461f9f9dbd30c8ceedf0f8986285f909ec563"
+  ],
+  "key_set": [
+    {
+      "gatekeeper_key_id": "2222222222222222222222222222222222222222222222222222222222222222",
+      "key_version": 1,
+      "pubkey": "ed25519:KKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKK"
+    }
+  ],
+  "status": "halted",
+  "receipt_hash": "1321c46b407acabd5978b4738a44b80f647dbf1e6bcdd95ff45e5492c943f5ff"
+}

--- a/vectors/RunReceipt/v8.8.0/invalid/wrong-genesis-anchor.json
+++ b/vectors/RunReceipt/v8.8.0/invalid/wrong-genesis-anchor.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "genesis_anchor not the pinned literal — structural rejection (Type.Literal).",
+  "receipt_kind": "legba_run_receipt",
+  "contract_version": "8.8.0",
+  "run_id": "vec-run",
+  "genesis_anchor": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+  "token_hash_sequence": [
+    "sha256:7a5eacb885e422af7486518123c461f9f9dbd30c8ceedf0f8986285f909ec563"
+  ],
+  "key_set": [
+    {
+      "gatekeeper_key_id": "2222222222222222222222222222222222222222222222222222222222222222",
+      "key_version": 1,
+      "pubkey": "ed25519:KKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKK"
+    }
+  ],
+  "status": "passed",
+  "receipt_hash": "1321c46b407acabd5978b4738a44b80f647dbf1e6bcdd95ff45e5492c943f5ff"
+}

--- a/vectors/RunReceipt/v8.8.0/valid/blocked-at-gate.json
+++ b/vectors/RunReceipt/v8.8.0/valid/blocked-at-gate.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "blocked_at_gate_0 terminal status; receipt_hash recomputed.",
+  "receipt_kind": "legba_run_receipt",
+  "contract_version": "8.8.0",
+  "run_id": "vec-run",
+  "genesis_anchor": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "token_hash_sequence": [
+    "sha256:7a5eacb885e422af7486518123c461f9f9dbd30c8ceedf0f8986285f909ec563"
+  ],
+  "key_set": [
+    {
+      "gatekeeper_key_id": "2222222222222222222222222222222222222222222222222222222222222222",
+      "key_version": 1,
+      "pubkey": "ed25519:KKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKK"
+    }
+  ],
+  "status": "blocked_at_gate_0",
+  "receipt_hash": "382d3659e9c07e7f2ba261898fafbbe32d58751d35d2315d8220f5a88c793c66"
+}

--- a/vectors/RunReceipt/v8.8.0/valid/passed-single-gate.json
+++ b/vectors/RunReceipt/v8.8.0/valid/passed-single-gate.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "Passed run; receipt_hash covers {genesis_anchor,token_hash_sequence,key_set,status}.",
+  "receipt_kind": "legba_run_receipt",
+  "contract_version": "8.8.0",
+  "run_id": "vec-run",
+  "genesis_anchor": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "token_hash_sequence": [
+    "sha256:7a5eacb885e422af7486518123c461f9f9dbd30c8ceedf0f8986285f909ec563"
+  ],
+  "key_set": [
+    {
+      "gatekeeper_key_id": "2222222222222222222222222222222222222222222222222222222222222222",
+      "key_version": 1,
+      "pubkey": "ed25519:KKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKK"
+    }
+  ],
+  "status": "passed",
+  "receipt_hash": "1321c46b407acabd5978b4738a44b80f647dbf1e6bcdd95ff45e5492c943f5ff"
+}

--- a/vectors/SpanMove/v8.8.0/invalid-cross-field/re-executable-missing-env-fingerprint.json
+++ b/vectors/SpanMove/v8.8.0/invalid-cross-field/re-executable-missing-env-fingerprint.json
@@ -1,0 +1,16 @@
+{
+  "_comment": "LM-4: re_executable move lacks env_fingerprint (schema-valid; cross-field reject).",
+  "move_kind": "legba_span_move",
+  "contract_version": "8.8.0",
+  "run_id": "vec-run",
+  "span_index": 0,
+  "seq": 1,
+  "prev_hash": "sha256:f28d6dfa8dd41376fbbb78839cff5a498b2f13246aa91b99177fc93bd69b80c9",
+  "kind": "tool",
+  "determinism": "re_executable",
+  "tool": "augury_sweep",
+  "input_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "output_hash": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+  "ts": "2026-06-11T00:00:01.000000Z",
+  "record_hash": "cd6dc262d19fe65ae17df64e590f66706cdf7f0a0763b532bfc7606dedf3688d"
+}

--- a/vectors/SpanMove/v8.8.0/invalid-cross-field/record-hash-mismatch-post-edit.json
+++ b/vectors/SpanMove/v8.8.0/invalid-cross-field/record-hash-mismatch-post-edit.json
@@ -1,0 +1,16 @@
+{
+  "_comment": "LM-3/LG-2: body edited, record_hash stale (post-emit edit; cross-field reject).",
+  "move_kind": "legba_span_move",
+  "contract_version": "8.8.0",
+  "run_id": "vec-run",
+  "span_index": 0,
+  "seq": 0,
+  "prev_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "kind": "emission",
+  "determinism": "attestable",
+  "label": "tampered",
+  "input_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "output_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "ts": "2026-06-11T00:00:00.000000Z",
+  "record_hash": "f28d6dfa8dd41376fbbb78839cff5a498b2f13246aa91b99177fc93bd69b80c9"
+}

--- a/vectors/SpanMove/v8.8.0/invalid-cross-field/seq-gap.json
+++ b/vectors/SpanMove/v8.8.0/invalid-cross-field/seq-gap.json
@@ -1,0 +1,17 @@
+{
+  "_comment": "LM-1: seq jumps 0->5 (schema-valid integer; cross-field monotonicity reject).",
+  "move_kind": "legba_span_move",
+  "contract_version": "8.8.0",
+  "run_id": "vec-run",
+  "span_index": 0,
+  "seq": 5,
+  "prev_hash": "sha256:f28d6dfa8dd41376fbbb78839cff5a498b2f13246aa91b99177fc93bd69b80c9",
+  "kind": "tool",
+  "determinism": "re_executable",
+  "tool": "augury_sweep",
+  "input_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "output_hash": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+  "env_fingerprint": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+  "ts": "2026-06-11T00:00:01.000000Z",
+  "record_hash": "b30a5f705329c8a87cd749a107f97f1c5ae72d315a17765a7dea1b4f5e40dfeb"
+}

--- a/vectors/SpanMove/v8.8.0/invalid/bad-determinism-enum.json
+++ b/vectors/SpanMove/v8.8.0/invalid/bad-determinism-enum.json
@@ -1,0 +1,16 @@
+{
+  "_comment": "determinism not in {re_executable,attestable} — structural rejection.",
+  "move_kind": "legba_span_move",
+  "contract_version": "8.8.0",
+  "run_id": "vec-run",
+  "span_index": 0,
+  "seq": 0,
+  "prev_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "kind": "emission",
+  "determinism": "maybe",
+  "label": "plan",
+  "input_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "output_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "ts": "2026-06-11T00:00:00.000000Z",
+  "record_hash": "f28d6dfa8dd41376fbbb78839cff5a498b2f13246aa91b99177fc93bd69b80c9"
+}

--- a/vectors/SpanMove/v8.8.0/invalid/bad-input-hash-pattern.json
+++ b/vectors/SpanMove/v8.8.0/invalid/bad-input-hash-pattern.json
@@ -1,0 +1,16 @@
+{
+  "_comment": "input_hash violates the 64-hex sha256 pattern — structural rejection.",
+  "move_kind": "legba_span_move",
+  "contract_version": "8.8.0",
+  "run_id": "vec-run",
+  "span_index": 0,
+  "seq": 0,
+  "prev_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "kind": "emission",
+  "determinism": "attestable",
+  "label": "plan",
+  "input_hash": "not-a-hash",
+  "output_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "ts": "2026-06-11T00:00:00.000000Z",
+  "record_hash": "f28d6dfa8dd41376fbbb78839cff5a498b2f13246aa91b99177fc93bd69b80c9"
+}

--- a/vectors/SpanMove/v8.8.0/invalid/missing-discriminator.json
+++ b/vectors/SpanMove/v8.8.0/invalid/missing-discriminator.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "Missing required move_kind discriminator — structural rejection.",
+  "contract_version": "8.8.0",
+  "run_id": "vec-run",
+  "span_index": 0,
+  "seq": 0,
+  "prev_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "kind": "emission",
+  "determinism": "attestable",
+  "label": "plan",
+  "input_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "output_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "ts": "2026-06-11T00:00:00.000000Z",
+  "record_hash": "f28d6dfa8dd41376fbbb78839cff5a498b2f13246aa91b99177fc93bd69b80c9"
+}

--- a/vectors/SpanMove/v8.8.0/valid/attestable-emission-genesis.json
+++ b/vectors/SpanMove/v8.8.0/valid/attestable-emission-genesis.json
@@ -1,0 +1,16 @@
+{
+  "_comment": "Genesis attestable move; record_hash matches JCS(record minus record_hash).",
+  "move_kind": "legba_span_move",
+  "contract_version": "8.8.0",
+  "run_id": "vec-run",
+  "span_index": 0,
+  "seq": 0,
+  "prev_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "kind": "emission",
+  "determinism": "attestable",
+  "label": "plan",
+  "input_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "output_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "ts": "2026-06-11T00:00:00.000000Z",
+  "record_hash": "f28d6dfa8dd41376fbbb78839cff5a498b2f13246aa91b99177fc93bd69b80c9"
+}

--- a/vectors/SpanMove/v8.8.0/valid/re-executable-tool-chained.json
+++ b/vectors/SpanMove/v8.8.0/valid/re-executable-tool-chained.json
@@ -1,0 +1,17 @@
+{
+  "_comment": "re_executable tool move with env_fingerprint, chained to the genesis move.",
+  "move_kind": "legba_span_move",
+  "contract_version": "8.8.0",
+  "run_id": "vec-run",
+  "span_index": 0,
+  "seq": 1,
+  "prev_hash": "sha256:f28d6dfa8dd41376fbbb78839cff5a498b2f13246aa91b99177fc93bd69b80c9",
+  "kind": "tool",
+  "determinism": "re_executable",
+  "tool": "augury_sweep",
+  "input_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "output_hash": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+  "env_fingerprint": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+  "ts": "2026-06-11T00:00:01.000000Z",
+  "record_hash": "8bf3197745503554d778d51cebc0a733fdaec651d1c09b2d4a80df6e9a8dea4b"
+}


### PR DESCRIPTION
## Legba substrate schemas — cycle 1 (proposal for review)

Three crypto/chain-bearing integrity schemas for **Legba**, the operator substrate
that brings cryptographic validation to agentic state transitions (spans propose,
gates validate, ed25519 tokens carry custody, the run compiles to one verifiable
receipt hash). Authored in `loa-freeside`'s legba-substrate ladder, cycle 1 — the
"law" rung. This is the constitutional-schema half; the runtime (recorder,
gatekeeper, turnstile) lands in later cycles in `construct-rooms-substrate`.

**This is a proposal PR — not for auto-merge.** @janitooor owns what enters
hounfour; the open questions below are yours to decide before this ships.

### What's here

| Schema | Flags | Purpose |
|---|---|---|
| `SpanMove` | `x-chain-bearing` | one hash-chained move in a span log (LM-1..5) |
| `GateToken` | `x-crypto-bearing` `x-chain-bearing` | ed25519 turnstile key; wave-level under DAG fan-out (LT-1..5) |
| `RunReceipt` | `x-chain-bearing` | token-hash chain → one receipt hash; `receipt_hash` covers `key_set` (LR-1..4) |

Built to the `PhaseCompletionEnvelope` house style: shared pattern constants,
runtime-deferred vs library constraint classification, LOCAL key-id derivation,
4 KB canonical caps.

### Conformance wired (so CI is green, not aspirational)

- Constraint files with `type_signature` + `origin: genesis`.
- Generated JSON Schemas (registered in `generate-schemas.ts`; `GateToken` added
  to the `RULE_4_CRYPTO_BEARING_NAMES` lint registry).
- 21 vectors in `vectors/<Schema>/v8.8.0/{valid,invalid,invalid-cross-field}` +
  a structural-tier runner.
- Census + schema counts bumped (140→143 constraints, 262→265 schemas).
- **Full suite: 9539 pass.** The single red file (`cross-runner-manifest`) is a
  **pre-existing flake** — it fails identically on `main` with this branch
  stashed (a stdout/stderr interleave at the 8 KB pipe boundary, unrelated here).

### Deliberately deferred (the post-ratification follow-up)

Cross-field **validator implementations** + cross-field-validator **registry
wiring** are NOT in this PR. You don't implement validators for a shape that
isn't ratified yet — so the constraint files declare the invariants and the
`invalid-cross-field/` corpus stages the fixtures, ready for that work once you
accept the shapes. The structural tier (Value.Check) is fully covered now.

### Open questions for you

1. **Version literal.** Schemas pin their own `8.8.0` introduction literal
   (like `CanonicalRun` pins `8.6.0`); I left the global `CONTRACT_VERSION` at
   `8.7.0`. Bump to `8.8.0` now, or on release?
2. **`pubkey` encoding** in `RunReceipt.key_set[]` is consumer-shaped
   (`minLength: 1`). If there's a canonical ed25519-pubkey pattern constant, I'll
   tighten to it.
3. **`status` shape** — `RunReceipt.status` is `'passed' | '^blocked_at_gate_N$'`
   (string) for receipt-hash stability vs a structured `{blocked, gate_index}`.
   Your call on the trade.
4. **`type_signature` depth** — I populated field→primitive maps; the existing
   corpus mixes depths. Want richer signatures on the chain/crypto fields?

Full design context (PRD/SDD, Flatline review record, the playtest that motivated
the substrate) lives in `loa-freeside` `grimoires/loa/handoffs/2026-06-11-legba-cycle1-hounfour-schemas.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
