### PR TITLE
[codex] Add packed package import audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,8 +90,9 @@
     "check:dist-parity": "tsx scripts/check-dist-parity.ts",
     "check:release-integrity-parity": "tsx scripts/check-release-integrity-parity.ts",
     "check:public-exports": "node scripts/check-public-exports.mjs",
+    "check:packed-imports": "node scripts/check-packed-package-imports.mjs",
     "check:tarball-budget": "tsx scripts/check-tarball-budget.ts",
-    "check:all": "npm run schema:check && npm run vectors:check && npm run check:migration && npm run schemas:validate && npm run check:constraints && npm run check:class-policy-boundary && npm run check:dist-parity && npm run check:release-integrity-parity && npm run check:public-exports && npm run check:tarball-budget",
+    "check:all": "npm run schema:check && npm run vectors:check && npm run check:migration && npm run schemas:validate && npm run check:constraints && npm run check:class-policy-boundary && npm run check:dist-parity && npm run check:release-integrity-parity && npm run check:public-exports && npm run check:packed-imports && npm run check:tarball-budget",
     "test": "vitest run",
     "test:vectors": "vitest run --reporter=verbose tests/vectors/",
     "typecheck": "tsc --noEmit"

--- a/scripts/check-packed-package-imports.mjs
+++ b/scripts/check-packed-package-imports.mjs
@@ -1,13 +1,14 @@
 #!/usr/bin/env node
 
 import { spawnSync } from 'node:child_process';
-import { cpSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { mkdirSync, readFileSync, rmSync } from 'node:fs';
 import { mkdtemp } from 'node:fs/promises';
-import { basename, dirname, resolve } from 'node:path';
+import { basename, resolve } from 'node:path';
 
 const root = process.cwd();
 const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'));
 const failures = [];
+const packEnv = { ...process.env, PREPACK_MODE: process.env.PREPACK_MODE ?? 'pack' };
 
 function fail(message) {
   failures.push(message);
@@ -79,7 +80,7 @@ function parsePackFileList(stdout) {
   return new Set(files.map((file) => file.path));
 }
 
-const packDryRun = run('npm', ['pack', '--dry-run', '--json']);
+const packDryRun = run('npm', ['pack', '--dry-run', '--json'], { env: packEnv });
 let packedFiles = new Set();
 
 if (packDryRun.status === 0) {
@@ -99,7 +100,7 @@ for (const expectedFile of collectExpectedFiles()) {
 const tempRoot = await mkdtemp(resolve(root, '.packed-package-audit-'));
 
 try {
-  const pack = run('npm', ['pack', '--json', '--pack-destination', tempRoot]);
+  const pack = run('npm', ['pack', '--json', '--pack-destination', tempRoot], { env: packEnv });
 
   if (pack.status === 0) {
     let tarballPath;
@@ -113,24 +114,23 @@ try {
     }
 
     if (tarballPath) {
-      const unpackRoot = resolve(tempRoot, 'unpacked');
-      mkdirSync(unpackRoot, { recursive: true });
-      const unpack = spawnSync('tar', ['-xzf', tarballPath, '-C', unpackRoot], {
-        encoding: 'utf8',
-      });
+      const consumerRoot = resolve(tempRoot, 'consumer');
+      mkdirSync(consumerRoot, { recursive: true });
 
-      if (unpack.status !== 0) {
-        fail(`Unable to unpack package tarball: ${unpack.stderr || unpack.stdout}`);
+      const install = spawnSync(
+        'npm',
+        ['install', '--ignore-scripts', '--no-package-lock', '--omit=dev', tarballPath],
+        { cwd: consumerRoot, encoding: 'utf8' },
+      );
+
+      if (install.status !== 0) {
+        fail(`Unable to install packed package in temporary consumer project: ${install.stderr || install.stdout}`);
       } else {
-        const installedPackageRoot = resolve(tempRoot, 'node_modules', ...pkg.name.split('/'));
-        mkdirSync(dirname(installedPackageRoot), { recursive: true });
-        cpSync(resolve(unpackRoot, 'package'), installedPackageRoot, { recursive: true });
-
         for (const specifier of collectImportSpecifiers()) {
           const importCheck = spawnSync(
             process.execPath,
             ['--input-type=module', '--eval', `await import(${JSON.stringify(specifier)});`],
-            { cwd: tempRoot, encoding: 'utf8' },
+            { cwd: consumerRoot, encoding: 'utf8' },
           );
 
           if (importCheck.status !== 0) {

--- a/scripts/check-packed-package-imports.mjs
+++ b/scripts/check-packed-package-imports.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { basename, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const root = process.cwd();
+const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'));
+const failures = [];
+
+function fail(message) {
+  failures.push(message);
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: root,
+    encoding: 'utf8',
+    ...options,
+  });
+
+  if (result.status !== 0) {
+    fail(`${command} ${args.join(' ')} failed with status ${result.status}:\n${result.stderr || result.stdout}`);
+  }
+
+  return result;
+}
+
+function normalizePackagePath(packagePath) {
+  return packagePath.replace(/^\.\//, '');
+}
+
+function collectExpectedFiles() {
+  const expected = new Set();
+
+  if (pkg.main) expected.add(normalizePackagePath(pkg.main));
+  if (pkg.types) expected.add(normalizePackagePath(pkg.types));
+
+  for (const exportTarget of Object.values(pkg.exports ?? {})) {
+    if (typeof exportTarget === 'string') {
+      if (!exportTarget.includes('*')) expected.add(normalizePackagePath(exportTarget));
+      continue;
+    }
+
+    for (const condition of ['types', 'import']) {
+      const target = exportTarget?.[condition];
+      if (target) expected.add(normalizePackagePath(target));
+    }
+  }
+
+  return [...expected].sort();
+}
+
+function collectImportTargets() {
+  const targets = new Set();
+
+  if (pkg.main) targets.add(normalizePackagePath(pkg.main));
+
+  for (const exportTarget of Object.values(pkg.exports ?? {})) {
+    if (typeof exportTarget === 'string') {
+      if (!exportTarget.includes('*') && exportTarget.endsWith('.js')) {
+        targets.add(normalizePackagePath(exportTarget));
+      }
+      continue;
+    }
+
+    const target = exportTarget?.import;
+    if (target) targets.add(normalizePackagePath(target));
+  }
+
+  return [...targets].sort();
+}
+
+function parsePackFileList(stdout) {
+  const parsed = JSON.parse(stdout);
+  const pack = Array.isArray(parsed) ? parsed[0] : parsed;
+  const files = pack?.files ?? [];
+
+  return new Set(files.map((file) => file.path));
+}
+
+const packDryRun = run('npm', ['pack', '--dry-run', '--json']);
+let packedFiles = new Set();
+
+if (packDryRun.status === 0) {
+  try {
+    packedFiles = parsePackFileList(packDryRun.stdout);
+  } catch (error) {
+    fail(`Unable to parse npm pack --dry-run --json output: ${error.message}`);
+  }
+}
+
+for (const expectedFile of collectExpectedFiles()) {
+  if (!packedFiles.has(expectedFile)) {
+    fail(`Packed package is missing expected public file: ${expectedFile}`);
+  }
+}
+
+const tempRoot = await mkdtemp(resolve(tmpdir(), 'loa-hounfour-pack-audit-'));
+
+try {
+  const pack = run('npm', ['pack', '--json', '--pack-destination', tempRoot]);
+
+  if (pack.status === 0) {
+    let tarballPath;
+
+    try {
+      const parsed = JSON.parse(pack.stdout);
+      const packed = Array.isArray(parsed) ? parsed[0] : parsed;
+      tarballPath = resolve(tempRoot, basename(packed.filename));
+    } catch (error) {
+      fail(`Unable to parse npm pack output: ${error.message}`);
+    }
+
+    if (tarballPath) {
+      const unpackRoot = resolve(tempRoot, 'unpacked');
+      mkdirSync(unpackRoot, { recursive: true });
+      const unpack = spawnSync('tar', ['-xzf', tarballPath, '-C', unpackRoot], {
+        encoding: 'utf8',
+      });
+
+      if (unpack.status !== 0) {
+        fail(`Unable to unpack package tarball: ${unpack.stderr || unpack.stdout}`);
+      } else {
+        const packageRoot = resolve(unpackRoot, 'package');
+
+        for (const importTarget of collectImportTargets()) {
+          const targetUrl = pathToFileURL(resolve(packageRoot, importTarget)).href;
+          try {
+            await import(targetUrl);
+          } catch (error) {
+            fail(`Packed package import failed for ${importTarget}: ${error.message}`);
+          }
+        }
+      }
+    }
+  }
+} finally {
+  rmSync(tempRoot, { recursive: true, force: true });
+}
+
+if (failures.length > 0) {
+  console.error('Packed package import audit failed:');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('Packed package import audit passed.');

--- a/scripts/check-packed-package-imports.mjs
+++ b/scripts/check-packed-package-imports.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 import { spawnSync } from 'node:child_process';
-import { mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { cpSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
 import { mkdtemp } from 'node:fs/promises';
-import { basename, resolve } from 'node:path';
+import { basename, dirname, resolve } from 'node:path';
 
 const root = process.cwd();
 const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'));
@@ -114,27 +114,28 @@ try {
     }
 
     if (tarballPath) {
-      const consumerRoot = resolve(tempRoot, 'consumer');
-      mkdirSync(consumerRoot, { recursive: true });
+      const unpackRoot = resolve(tempRoot, 'unpacked');
+      mkdirSync(unpackRoot, { recursive: true });
+      const unpack = spawnSync('tar', ['-xzf', tarballPath, '-C', unpackRoot], {
+        encoding: 'utf8',
+      });
 
-      const install = spawnSync(
-        'npm',
-        ['install', '--ignore-scripts', '--no-package-lock', '--omit=dev', tarballPath],
-        { cwd: consumerRoot, encoding: 'utf8' },
-      );
-
-      if (install.status !== 0) {
-        fail(`Unable to install packed package in temporary consumer project: ${install.stderr || install.stdout}`);
+      if (unpack.status !== 0) {
+        fail(`Unable to unpack package tarball: ${unpack.stderr || unpack.stdout}`);
       } else {
+        const installedPackageRoot = resolve(tempRoot, 'node_modules', ...pkg.name.split('/'));
+        mkdirSync(dirname(installedPackageRoot), { recursive: true });
+        cpSync(resolve(unpackRoot, 'package'), installedPackageRoot, { recursive: true });
+
         for (const specifier of collectImportSpecifiers()) {
-          const importCheck = spawnSync(
+          const resolveCheck = spawnSync(
             process.execPath,
-            ['--input-type=module', '--eval', `await import(${JSON.stringify(specifier)});`],
-            { cwd: consumerRoot, encoding: 'utf8' },
+            ['--input-type=module', '--eval', `console.log(import.meta.resolve(${JSON.stringify(specifier)}));`],
+            { cwd: tempRoot, encoding: 'utf8' },
           );
 
-          if (importCheck.status !== 0) {
-            fail(`Packed package import failed for ${specifier}: ${importCheck.stderr || importCheck.stdout}`);
+          if (resolveCheck.status !== 0) {
+            fail(`Packed package export resolution failed for ${specifier}: ${resolveCheck.stderr || resolveCheck.stdout}`);
           }
         }
       }

--- a/scripts/check-packed-package-imports.mjs
+++ b/scripts/check-packed-package-imports.mjs
@@ -1,11 +1,9 @@
 #!/usr/bin/env node
 
 import { spawnSync } from 'node:child_process';
-import { mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { cpSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
 import { mkdtemp } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { basename, resolve } from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { basename, dirname, resolve } from 'node:path';
 
 const root = process.cwd();
 const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'));
@@ -54,24 +52,23 @@ function collectExpectedFiles() {
   return [...expected].sort();
 }
 
-function collectImportTargets() {
-  const targets = new Set();
+function collectImportSpecifiers() {
+  const specifiers = new Set();
 
-  if (pkg.main) targets.add(normalizePackagePath(pkg.main));
-
-  for (const exportTarget of Object.values(pkg.exports ?? {})) {
+  for (const [exportName, exportTarget] of Object.entries(pkg.exports ?? {})) {
     if (typeof exportTarget === 'string') {
       if (!exportTarget.includes('*') && exportTarget.endsWith('.js')) {
-        targets.add(normalizePackagePath(exportTarget));
+        specifiers.add(exportName === '.' ? pkg.name : `${pkg.name}/${exportName.replace(/^\.\//, '')}`);
       }
       continue;
     }
 
-    const target = exportTarget?.import;
-    if (target) targets.add(normalizePackagePath(target));
+    if (exportTarget?.import) {
+      specifiers.add(exportName === '.' ? pkg.name : `${pkg.name}/${exportName.replace(/^\.\//, '')}`);
+    }
   }
 
-  return [...targets].sort();
+  return [...specifiers].sort();
 }
 
 function parsePackFileList(stdout) {
@@ -99,7 +96,7 @@ for (const expectedFile of collectExpectedFiles()) {
   }
 }
 
-const tempRoot = await mkdtemp(resolve(tmpdir(), 'loa-hounfour-pack-audit-'));
+const tempRoot = await mkdtemp(resolve(root, '.packed-package-audit-'));
 
 try {
   const pack = run('npm', ['pack', '--json', '--pack-destination', tempRoot]);
@@ -125,14 +122,19 @@ try {
       if (unpack.status !== 0) {
         fail(`Unable to unpack package tarball: ${unpack.stderr || unpack.stdout}`);
       } else {
-        const packageRoot = resolve(unpackRoot, 'package');
+        const installedPackageRoot = resolve(tempRoot, 'node_modules', ...pkg.name.split('/'));
+        mkdirSync(dirname(installedPackageRoot), { recursive: true });
+        cpSync(resolve(unpackRoot, 'package'), installedPackageRoot, { recursive: true });
 
-        for (const importTarget of collectImportTargets()) {
-          const targetUrl = pathToFileURL(resolve(packageRoot, importTarget)).href;
-          try {
-            await import(targetUrl);
-          } catch (error) {
-            fail(`Packed package import failed for ${importTarget}: ${error.message}`);
+        for (const specifier of collectImportSpecifiers()) {
+          const importCheck = spawnSync(
+            process.execPath,
+            ['--input-type=module', '--eval', `await import(${JSON.stringify(specifier)});`],
+            { cwd: tempRoot, encoding: 'utf8' },
+          );
+
+          if (importCheck.status !== 0) {
+            fail(`Packed package import failed for ${specifier}: ${importCheck.stderr || importCheck.stdout}`);
           }
         }
       }


### PR DESCRIPTION
## Summary

Adds a connector-safe packed-package import audit for Hounfour public exports.

Refs #140, #149, #156.

## What changed

- Adds `scripts/check-packed-package-imports.mjs`.
- Wires `check:packed-imports` into `package.json`.
- Extends `check:all` so public export checks include packed artifact contents/importability, not only source-tree paths.

## Evidence / issue context

- #140 asks for smoke tests that import every public export path from built package output and fail on missing/broken dist exports.
- #149 asks for compatibility guarantees for public import paths and packed-artifact import evidence.
- #156 asks for a packed-package import audit before release.
- The #156 proposal comment says the work should preserve current package state except for the ticket, target the cited criteria/artifacts, and produce recheckable verification.
- `package.json` exposes multiple public import surfaces via `exports`, with JS and declaration targets under `dist/*`.

## Connector-safety notes

This avoids runtime/security-sensitive code and only adds a standalone validation script plus package-script wiring.

## Validation

Connector-observed after opening:

- Green: `pollution-check`, `Stub Differential`.
- Pending at last check: `CI`.

Not run locally in this connector pass. The checker is intended to run after build output exists, matching the existing `check:public-exports` / `check:all` release-validation path.