### PR TITLE
[codex] Add release parity PR evidence template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Summary
+
+<!-- What changed? Keep this scoped to the PR. -->
+
+## Related issues
+
+Refs #
+
+## Validation evidence
+
+<!-- Paste exact command output or explain why a command is not applicable. -->
+
+- [ ] `npm run typecheck`
+- [ ] `npm run build`
+- [ ] `npm run test`
+- [ ] `npm run check:all`
+
+## Release parity evidence
+
+Required for release or package-surface PRs. Leave checked as not applicable only when the PR does not affect release artifacts, public exports, generated schemas, vectors, constraints, or release integrity metadata.
+
+- [ ] `npm run check:all` output is included above, or an equivalent release gate is named with rationale.
+- [ ] Source/dist parity was checked.
+- [ ] Generated JSON schemas were checked.
+- [ ] Vector and constraint artifacts were checked.
+- [ ] Release integrity metadata was checked.
+- [ ] Public export / packed package evidence was checked when package exports changed.
+
+## Non-claims
+
+<!-- Name related work this PR does not complete. -->


### PR DESCRIPTION
## Summary

Adds a repository PR template with explicit validation and release-parity evidence fields.

Refs #159.

## What changed

- Adds `.github/pull_request_template.md`.
- Requires PR authors to paste exact validation output or explain non-applicability.
- Adds a release/package-surface section for `check:all`, source/dist parity, schema, vector, constraint, release-integrity, and public export / packed package evidence.

## Evidence / issue context

- #159 asks release PRs to include parity check output for source, dist, schemas, vectors, constraints, and release integrity metadata.
- #159 acceptance criteria require release PRs to include parity evidence and make exact command output visible to reviewers.
- The #159 proposal comment asks for a focused verified change and no unrelated package work.

## Connector-safety notes

This is documentation/process-only and does not touch runtime code, package build behavior, security policy, schema generation, migrations, or release thresholds.

## Validation

Not run locally in this connector pass. This PR adds a PR template only; relevant validation is GitHub-rendered template presence plus PR review of the file contents.